### PR TITLE
Fix turn number reset bug

### DIFF
--- a/src/GameInitializer.cpp
+++ b/src/GameInitializer.cpp
@@ -103,9 +103,7 @@ void GameInitializer::resetGameState(GameState& gameState) {
     gameState.setGameResult(GameResult::IN_PROGRESS);
     
     // Reset turn number to 1
-    while (gameState.getTurnNumber() > 1) {
-        gameState.incrementTurnNumber();
-    }
+    gameState.setTurnNumber(1);
     
     // Reset steam for both players
     gameState.setSteam(PlayerSide::PLAYER_ONE, 0);


### PR DESCRIPTION
## Summary
- correct resetting of the turn number in `GameInitializer`
- build CMake project and run server tests

## Testing
- `cmake -S . -B build`
- `cmake --build build -j2`
- `./tests/BayouBonanzaTests`
- `./tests/BayouBonanzaClientTests` *(fails: Failed to open X11 display)*

------
https://chatgpt.com/codex/tasks/task_e_683f428aa2d883229b3adc5ee01da6e6