### PR TITLE
Add move highlight support

### DIFF
--- a/include/GraphicsManager.h
+++ b/include/GraphicsManager.h
@@ -27,6 +27,9 @@ public:
     
     // Convert game coordinates to screen coordinates
     sf::Vector2i gameToScreen(const sf::Vector2f& gamePos) const;
+
+    // Convert game coordinates to board coordinates
+    sf::Vector2i gameToBoard(const sf::Vector2f& gamePos) const;
     
     // Get the game board rendering parameters
     struct BoardRenderParams {

--- a/src/GraphicsManager.cpp
+++ b/src/GraphicsManager.cpp
@@ -65,6 +65,20 @@ sf::Vector2i GraphicsManager::gameToScreen(const sf::Vector2f& gamePos) const {
     return screenPos;
 }
 
+sf::Vector2i GraphicsManager::gameToBoard(const sf::Vector2f& gamePos) const {
+    BoardRenderParams params = getBoardRenderParams();
+
+    int boardX = static_cast<int>((gamePos.x - params.boardStartX) / params.squareSize);
+    int boardY = static_cast<int>((gamePos.y - params.boardStartY) / params.squareSize);
+
+    if (boardX >= 0 && boardX < GameBoard::BOARD_SIZE &&
+        boardY >= 0 && boardY < GameBoard::BOARD_SIZE) {
+        return sf::Vector2i(boardX, boardY);
+    }
+
+    return sf::Vector2i(-1, -1);
+}
+
 GraphicsManager::BoardRenderParams GraphicsManager::getBoardRenderParams() const {
     BoardRenderParams params;
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "InfluenceSystem.h" // Added for InfluenceSystem
 #include "GameOverDetector.h"
 #include "CardPlayValidator.h"
+#include "PieceData.h" // For Position
 #include "PieceCard.h"
 #include "EffectCard.h"
 // #include "King.h" // Removed - using data-driven approach with PieceFactory
@@ -783,6 +784,36 @@ int main()
             }
         }
         // --- End Control Visualization ---
+
+        // --- Move Highlighting ---
+        std::vector<Position> highlightSquares;
+        const Piece* highlightPiece = nullptr;
+        if (inputManager.isPieceSelected() && inputManager.getSelectedPiece()) {
+            highlightPiece = inputManager.getSelectedPiece();
+        } else {
+            sf::Vector2i mouseScreen = sf::Mouse::getPosition(window);
+            sf::Vector2f mouseGame = graphicsManager.screenToGame(mouseScreen);
+            sf::Vector2i boardCoords = graphicsManager.gameToBoard(mouseGame);
+            if (boardCoords.x >= 0 && boardCoords.y >= 0) {
+                const Square& hovered = board.getSquare(boardCoords.x, boardCoords.y);
+                if (!hovered.isEmpty()) {
+                    highlightPiece = hovered.getPiece();
+                }
+            }
+        }
+
+        if (highlightPiece) {
+            highlightSquares = highlightPiece->getValidMoves(board);
+        }
+
+        for (const Position& pos : highlightSquares) {
+            sf::RectangleShape highlightRect(sf::Vector2f(boardParams.squareSize, boardParams.squareSize));
+            highlightRect.setPosition(boardParams.boardStartX + pos.x * boardParams.squareSize,
+                                      boardParams.boardStartY + pos.y * boardParams.squareSize);
+            highlightRect.setFillColor(sf::Color(255, 255, 0, 120));
+            window.draw(highlightRect);
+        }
+        // --- End Move Highlighting ---
 
         // --- Piece Rendering ---
         for (int y = 0; y < GameBoard::BOARD_SIZE; ++y) {


### PR DESCRIPTION
## Summary
- allow GraphicsManager to convert game coordinates to board
- show valid move destinations when hovering and dragging pieces

## Testing
- `cmake ..` *(fails: Missing item in X11_X11_LIB;X11_Xrandr_LIB)*

------
https://chatgpt.com/codex/tasks/task_e_6847d65c31348322ba41891d5ac11221