### PR TITLE
Implement basic deck editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,11 @@ target_link_libraries(GameplayTest GameLogic)
 add_executable(TestInitialization test_initialization.cpp)
 target_link_libraries(TestInitialization GameLogic)
 
+# Add deck validation test executable
+add_executable(DeckValidationTest test_deck_validation.cpp)
+target_link_libraries(DeckValidationTest PRIVATE GameLogic)
+target_include_directories(DeckValidationTest PRIVATE include)
+
 # Set Visual Studio debugger working directory to project root for client
 set_target_properties(BayouBonanzaClient PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -53,6 +53,16 @@ The Bayou Bonanza server is configured to automatically initialize the database 
 
 5. **`decks` Table:** Stores the player's current deck in serialized form. Only one deck per user is supported.
 
+6. **Starter Collection:** New users automatically receive a starter collection of 20 cards that includes cards for all piece types:
+   - 6 Sentroid cards (common, basic pieces)
+   - 3 Rustbucket cards (common, ranged pieces)
+   - 2 Sweetykins cards (uncommon, rook-like movement)
+   - 2 Automatick cards (uncommon, knight-like movement)
+   - 2 Sidewinder cards (uncommon, bishop-like movement)
+   - 1 ScarlettGlumpkin card (rare, queen-like piece)
+   - 1 TinkeringTom card (rare, king-like piece)
+   - 3 Healing Light effect cards
+
 No manual schema creation is required.
 
 ## Troubleshooting

--- a/docs/DATABASE_SETUP.md
+++ b/docs/DATABASE_SETUP.md
@@ -49,6 +49,10 @@ The Bayou Bonanza server is configured to automatically initialize the database 
    * `username` (TEXT, PRIMARY KEY, NOT NULL): The player's unique username.
    * `rating` (INTEGER, NOT NULL, DEFAULT 1000): The player's Elo rating, defaulting to 1000 for new players.
 
+4. **`collections` Table:** Stores each player's owned cards as a serialized list.
+
+5. **`decks` Table:** Stores the player's current deck in serialized form. Only one deck per user is supported.
+
 No manual schema creation is required.
 
 ## Troubleshooting

--- a/include/CardCollection.h
+++ b/include/CardCollection.h
@@ -283,6 +283,14 @@ public:
     bool isValid() const;
     
     /**
+     * @brief Check if the deck is valid for editing/saving purposes
+     * 
+     * Allows incomplete decks (< 20 cards) but still enforces max copies rule
+     * @return true if the deck is valid for editing
+     */
+    bool isValidForEditing() const;
+    
+    /**
      * @brief Get the number of cards remaining in the deck
      * 
      * @return Number of cards left to draw

--- a/include/GameInitializer.h
+++ b/include/GameInitializer.h
@@ -32,6 +32,11 @@ public:
      * @param gameState Game state to initialize
      */
     void initializeNewGame(GameState& gameState);
+
+    /**
+     * @brief Initialize a new game state with custom decks
+     */
+    void initializeNewGame(GameState& gameState, const Deck& deck1, const Deck& deck2);
     
     /**
      * @brief Set up the initial board configuration

--- a/include/GameState.h
+++ b/include/GameState.h
@@ -293,6 +293,11 @@ public:
      * Creates starter decks and draws initial hands.
      */
     void initializeCardSystem();
+
+    /**
+     * @brief Initialize card system with custom decks
+     */
+    void initializeCardSystem(const Deck& deck1, const Deck& deck2);
     
     /**
      * @brief Process card-related turn start events

--- a/include/NetworkProtocol.h
+++ b/include/NetworkProtocol.h
@@ -21,7 +21,9 @@ enum class MessageType : sf::Uint8 {
     UserLogin,              // Client to Server: Sends username for login/registration
     CardCollectionData,     // Server to Client: Sends player's full card collection
     DeckData,               // Server to Client: Sends the player's deck
-    SaveDeck                // Client to Server: Save deck changes
+    SaveDeck,               // Client to Server: Save deck changes
+    DeckSaved,              // Server to Client: Confirmation that deck was saved successfully
+    RequestMatchmaking      // Client to Server: Request to be matched with another player
 };
 
 /**

--- a/include/NetworkProtocol.h
+++ b/include/NetworkProtocol.h
@@ -18,7 +18,10 @@ enum class MessageType : sf::Uint8 {
     Error,                  // Server to Client or Client to Server: Generic error message
     Ping,                   // Client to Server (optional, for keep-alive)
     Pong,                   // Server to Client (optional, for keep-alive)
-    UserLogin               // Client to Server: Sends username for login/registration
+    UserLogin,              // Client to Server: Sends username for login/registration
+    CardCollectionData,     // Server to Client: Sends player's full card collection
+    DeckData,               // Server to Client: Sends the player's deck
+    SaveDeck                // Client to Server: Save deck changes
 };
 
 /**

--- a/src/CardCollection.cpp
+++ b/src/CardCollection.cpp
@@ -282,6 +282,12 @@ bool Deck::isValid() const {
     return validate(DECK_SIZE, MAX_COPIES) && size() == DECK_SIZE;
 }
 
+bool Deck::isValidForEditing() const {
+    // For editing, we only check max copies rule, not the exact size requirement
+    // This allows players to save incomplete decks while building
+    return validate(0, MAX_COPIES); // 0 = no size limit, but enforce max copies
+}
+
 size_t Deck::cardsRemaining() const {
     return size();
 }

--- a/src/CardFactory.cpp
+++ b/src/CardFactory.cpp
@@ -123,30 +123,44 @@ std::vector<std::unique_ptr<Card>> CardFactory::createStarterDeck() {
     
     std::vector<std::unique_ptr<Card>> deck;
     
-    // Create a balanced starter deck with 20 cards using predefined card definitions
-            // 8 Sentroid cards (use predefined card ID 1)
-        for (int i = 0; i < 8; i++) {
-            deck.push_back(createCard(1)); // Summon Sentroid
-        }
+    // Create a balanced starter deck with 20 cards including all piece types
+    // Each player gets cards for all 7 piece types
     
-            // 4 Sweetykins cards (use predefined card ID 2)
-        for (int i = 0; i < 4; i++) {
-            deck.push_back(createCard(2)); // Summon Sweetykins
+    // 6 Sentroid cards (common, low cost) - ID 1
+    for (int i = 0; i < 6; i++) {
+        deck.push_back(createCard(1)); // Summon Sentroid
     }
     
-            // 4 Automatick cards (use predefined card ID 3)
-        for (int i = 0; i < 4; i++) {
-            deck.push_back(createCard(3)); // Summon Automatick
-        }
+    // 3 Rustbucket cards (common, ranged) - ID 7
+    for (int i = 0; i < 3; i++) {
+        deck.push_back(createCard(7)); // Summon Rustbucket
+    }
     
-    // 2 Bishop cards (use predefined card ID 4)
+    // 2 Sweetykins cards (uncommon, rook-like) - ID 2
     for (int i = 0; i < 2; i++) {
-        deck.push_back(createCard(4)); // Summon Bishop
+        deck.push_back(createCard(2)); // Summon Sweetykins
     }
     
-    // 2 Effect cards (healing) - use predefined card definitions
-    deck.push_back(createCard(10)); // Healing Light
-    deck.push_back(createCard(10)); // Healing Light
+    // 2 Automatick cards (uncommon, knight-like) - ID 3
+    for (int i = 0; i < 2; i++) {
+        deck.push_back(createCard(3)); // Summon Automatick
+    }
+    
+    // 2 Sidewinder cards (uncommon, bishop-like) - ID 4
+    for (int i = 0; i < 2; i++) {
+        deck.push_back(createCard(4)); // Summon Sidewinder
+    }
+    
+    // 1 ScarlettGlumpkin card (rare, queen-like) - ID 5
+    deck.push_back(createCard(5)); // Summon ScarlettGlumpkin
+    
+    // 1 TinkeringTom card (rare, king-like) - ID 6
+    deck.push_back(createCard(6)); // Summon TinkeringTom
+    
+    // 3 Effect cards (healing) - use predefined card definitions
+    for (int i = 0; i < 3; i++) {
+        deck.push_back(createCard(10)); // Healing Light
+    }
     
     return deck;
 }
@@ -299,6 +313,18 @@ void CardFactory::createDefaultDefinitions() {
                             8, CardType::PIECE_CARD, CardRarity::RARE);
     queenCard.pieceType = "ScarlettGlumpkin";
     cardDefinitions[5] = queenCard;
+    
+    // Add TinkeringTom card definition
+    CardDefinition tinkeringTomCard(6, "Summon TinkeringTom", "Summon a TinkeringTom piece to the battlefield",
+                                   7, CardType::PIECE_CARD, CardRarity::RARE);
+    tinkeringTomCard.pieceType = "TinkeringTom";
+    cardDefinitions[6] = tinkeringTomCard;
+    
+    // Add Rustbucket card definition  
+    CardDefinition rustbucketCard(7, "Summon Rustbucket", "Summon a Rustbucket piece to the battlefield",
+                                 3, CardType::PIECE_CARD, CardRarity::COMMON);
+    rustbucketCard.pieceType = "Rustbucket";
+    cardDefinitions[7] = rustbucketCard;
     
     // Create default effect cards
     CardDefinition healCard(10, "Healing Light", "Restore 25 health to target piece", 

--- a/src/GameInitializer.cpp
+++ b/src/GameInitializer.cpp
@@ -31,6 +31,13 @@ void GameInitializer::initializeNewGame(GameState& gameState) {
     calculateInitialControl(gameState);
 }
 
+void GameInitializer::initializeNewGame(GameState& gameState, const Deck& deck1, const Deck& deck2) {
+    resetGameState(gameState);
+    setupBoard(gameState);
+    gameState.initializeCardSystem(deck1, deck2);
+    calculateInitialControl(gameState);
+}
+
 void GameInitializer::setupBoard(GameState& gameState) {
     // Clear the board
     gameState.getBoard().resetBoard();

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -318,10 +318,8 @@ void GameState::initializeCardSystem() {
 void GameState::initializeCardSystem(const Deck& deck1, const Deck& deck2) {
     CardFactory::initialize();
 
-    deckPlayer1.clear();
-    deckPlayer1.copyFrom(deck1);
-    deckPlayer2.clear();
-    deckPlayer2.copyFrom(deck2);
+    deckPlayer1 = deck1;  // Use copy assignment operator
+    deckPlayer2 = deck2;  // Use copy assignment operator
 
     deckPlayer1.shuffle();
     deckPlayer2.shuffle();

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -315,6 +315,26 @@ void GameState::initializeCardSystem() {
     }
 }
 
+void GameState::initializeCardSystem(const Deck& deck1, const Deck& deck2) {
+    CardFactory::initialize();
+
+    deckPlayer1.clear();
+    deckPlayer1.copyFrom(deck1);
+    deckPlayer2.clear();
+    deckPlayer2.copyFrom(deck2);
+
+    deckPlayer1.shuffle();
+    deckPlayer2.shuffle();
+
+    handPlayer1.clear();
+    handPlayer2.clear();
+
+    for (int i = 0; i < Hand::MAX_HAND_SIZE; i++) {
+        drawCard(PlayerSide::PLAYER_ONE);
+        drawCard(PlayerSide::PLAYER_TWO);
+    }
+}
+
 void GameState::processCardTurnStart() {
     // Draw a card for the active player if their hand isn't full
     if (!getHand(activePlayer).isFull()) {

--- a/tests/CardTests.cpp
+++ b/tests/CardTests.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 #include <iostream>
 #include <typeinfo>
+#include <map>
 
 using namespace BayouBonanza;
 
@@ -240,6 +241,8 @@ TEST_CASE_METHOD(CardTestFixture, "CardFactory Functionality", "[card][factory]"
             REQUIRE(card->getSteamCost() >= 0);
         }
     }
+    
+
 }
 
 TEST_CASE_METHOD(CardTestFixture, "CardCollection Functionality", "[card][collection]") {
@@ -527,6 +530,59 @@ TEST_CASE("Debug EffectCard Issue", "[debug]") {
     // Test canPlay
     bool canPlay = healCard->canPlay(gameState, PlayerSide::PLAYER_ONE);
     REQUIRE(canPlay);
+}
+
+TEST_CASE_METHOD(CardTestFixture, "Starter Deck Contains All Piece Types", "[card][factory][starter]")
+{
+    SECTION("Starter Deck Creation and Content Verification") {
+        auto starterDeck = CardFactory::createStarterDeck();
+        REQUIRE(!starterDeck.empty());
+        REQUIRE(starterDeck.size() == 20); // Exact deck size
+        
+        // Count cards by piece type
+        std::map<std::string, int> pieceTypeCounts;
+        int effectCardCount = 0;
+        
+        for (const auto& card : starterDeck) {
+            REQUIRE(card != nullptr);
+            REQUIRE(!card->getName().empty());
+            REQUIRE(card->getSteamCost() >= 0);
+            
+            if (card->getCardType() == CardType::PIECE_CARD) {
+                auto pieceCard = dynamic_cast<const PieceCard*>(card.get());
+                REQUIRE(pieceCard != nullptr);
+                pieceTypeCounts[pieceCard->getPieceType()]++;
+            } else if (card->getCardType() == CardType::EFFECT_CARD) {
+                effectCardCount++;
+            }
+        }
+        
+        // Verify all requested piece types are present
+        REQUIRE(pieceTypeCounts["TinkeringTom"] >= 1);
+        REQUIRE(pieceTypeCounts["ScarlettGlumpkin"] >= 1);
+        REQUIRE(pieceTypeCounts["Sweetykins"] >= 1);
+        REQUIRE(pieceTypeCounts["Sidewinder"] >= 1);
+        REQUIRE(pieceTypeCounts["Automatick"] >= 1);
+        REQUIRE(pieceTypeCounts["Sentroid"] >= 1);
+        REQUIRE(pieceTypeCounts["Rustbucket"] >= 1);
+        
+        // Verify expected counts
+        REQUIRE(pieceTypeCounts["Sentroid"] == 6);
+        REQUIRE(pieceTypeCounts["Rustbucket"] == 3);
+        REQUIRE(pieceTypeCounts["Sweetykins"] == 2);
+        REQUIRE(pieceTypeCounts["Automatick"] == 2);
+        REQUIRE(pieceTypeCounts["Sidewinder"] == 2);
+        REQUIRE(pieceTypeCounts["ScarlettGlumpkin"] == 1);
+        REQUIRE(pieceTypeCounts["TinkeringTom"] == 1);
+        REQUIRE(effectCardCount == 3);
+        
+        // Verify total adds up to 20
+        int totalPieceCards = 0;
+        for (const auto& pair : pieceTypeCounts) {
+            totalPieceCards += pair.second;
+        }
+        REQUIRE(totalPieceCards + effectCardCount == 20);
+    }
 }
 
  


### PR DESCRIPTION
## Summary
- extend network protocol with deck-related messages
- add database tables for card collections and decks
- load and send player collection/deck on login
- allow saving deck changes from the client
- provide simple in-game deck editor screen

## Testing
- `cmake ..` *(fails: Missing X11 libraries)*
- `ctest --output-on-failure` *(no tests run due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6854e2b9b5408322b1870d7d34e19e9d