### PR TITLE
Flip board orientation

### DIFF
--- a/include/GraphicsManager.h
+++ b/include/GraphicsManager.h
@@ -30,6 +30,10 @@ public:
 
     // Convert game coordinates to board coordinates
     sf::Vector2i gameToBoard(const sf::Vector2f& gamePos) const;
+
+    // Convert board coordinates to game coordinates (accounting for board
+    // orientation)
+    sf::Vector2f boardToGame(int boardX, int boardY) const;
     
     // Get the game board rendering parameters
     struct BoardRenderParams {

--- a/src/GraphicsManager.cpp
+++ b/src/GraphicsManager.cpp
@@ -68,15 +68,26 @@ sf::Vector2i GraphicsManager::gameToScreen(const sf::Vector2f& gamePos) const {
 sf::Vector2i GraphicsManager::gameToBoard(const sf::Vector2f& gamePos) const {
     BoardRenderParams params = getBoardRenderParams();
 
-    int boardX = static_cast<int>((gamePos.x - params.boardStartX) / params.squareSize);
-    int boardY = static_cast<int>((gamePos.y - params.boardStartY) / params.squareSize);
+    int rotatedX = static_cast<int>((gamePos.x - params.boardStartX) / params.squareSize);
+    int rotatedY = static_cast<int>((gamePos.y - params.boardStartY) / params.squareSize);
 
-    if (boardX >= 0 && boardX < GameBoard::BOARD_SIZE &&
-        boardY >= 0 && boardY < GameBoard::BOARD_SIZE) {
+    if (rotatedX >= 0 && rotatedX < GameBoard::BOARD_SIZE &&
+        rotatedY >= 0 && rotatedY < GameBoard::BOARD_SIZE) {
+        int boardX = rotatedY;
+        int boardY = GameBoard::BOARD_SIZE - 1 - rotatedX;
         return sf::Vector2i(boardX, boardY);
     }
 
     return sf::Vector2i(-1, -1);
+}
+
+sf::Vector2f GraphicsManager::boardToGame(int boardX, int boardY) const {
+    BoardRenderParams params = getBoardRenderParams();
+    int rotatedX = GameBoard::BOARD_SIZE - 1 - boardY;
+    int rotatedY = boardX;
+    float gameX = params.boardStartX + rotatedX * params.squareSize;
+    float gameY = params.boardStartY + rotatedY * params.squareSize;
+    return sf::Vector2f(gameX, gameY);
 }
 
 GraphicsManager::BoardRenderParams GraphicsManager::getBoardRenderParams() const {

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -85,17 +85,7 @@ void InputManager::resetInputState() {
 }
 
 sf::Vector2i InputManager::gamePosToBoard(const sf::Vector2f& gamePos) const {
-    auto boardParams = graphicsManager.getBoardRenderParams();
-    
-    int boardX = static_cast<int>((gamePos.x - boardParams.boardStartX) / boardParams.squareSize);
-    int boardY = static_cast<int>((gamePos.y - boardParams.boardStartY) / boardParams.squareSize);
-    
-    if (boardX >= 0 && boardX < GameBoard::BOARD_SIZE && 
-        boardY >= 0 && boardY < GameBoard::BOARD_SIZE) {
-        return sf::Vector2i(boardX, boardY);
-    }
-    
-    return sf::Vector2i(-1, -1); // Invalid position
+    return graphicsManager.gameToBoard(gamePos);
 }
 
 void InputManager::handleMouseButtonPressed(const sf::Event& event) {
@@ -176,10 +166,8 @@ void InputManager::selectPiece(int boardX, int boardY, const sf::Vector2f& gameM
     pieceSelected = true;
     
     // Calculate offset in game coordinates
-    auto boardParams = graphicsManager.getBoardRenderParams();
-    float pieceGameX = boardParams.boardStartX + boardX * boardParams.squareSize;
-    float pieceGameY = boardParams.boardStartY + boardY * boardParams.squareSize;
-    mouseOffset = sf::Vector2f(gameMousePos.x - pieceGameX, gameMousePos.y - pieceGameY);
+    sf::Vector2f piecePos = graphicsManager.boardToGame(boardX, boardY);
+    mouseOffset = sf::Vector2f(gameMousePos.x - piecePos.x, gameMousePos.y - piecePos.y);
     currentMousePosition = gameMousePos;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1195,9 +1195,9 @@ int main()
 
         for (int y = 0; y < GameBoard::BOARD_SIZE; ++y) {
             for (int x = 0; x < GameBoard::BOARD_SIZE; ++x) {
+                sf::Vector2f squarePos = graphicsManager.boardToGame(x, y);
                 sf::RectangleShape squareShape(sf::Vector2f(boardParams.squareSize, boardParams.squareSize));
-                squareShape.setPosition(boardParams.boardStartX + x * boardParams.squareSize, 
-                                       boardParams.boardStartY + y * boardParams.squareSize);
+                squareShape.setPosition(squarePos);
 
                 // Alternate colors for chessboard pattern
                 if ((x + y) % 2 == 0) {
@@ -1217,9 +1217,9 @@ int main()
                 PlayerSide controller = InfluenceSystem::getControllingPlayer(square);
                 
                 if (controller != PlayerSide::NEUTRAL) {
+                    sf::Vector2f squarePos = graphicsManager.boardToGame(x, y);
                     sf::RectangleShape controlIndicator(sf::Vector2f(boardParams.squareSize, boardParams.squareSize));
-                    controlIndicator.setPosition(boardParams.boardStartX + x * boardParams.squareSize, 
-                                                boardParams.boardStartY + y * boardParams.squareSize);
+                    controlIndicator.setPosition(squarePos);
                     
                     if (controller == PlayerSide::PLAYER_ONE) {
                         // More visible blue tint for Player One control
@@ -1257,9 +1257,9 @@ int main()
         }
 
         for (const Position& pos : highlightSquares) {
+            sf::Vector2f squarePos = graphicsManager.boardToGame(pos.x, pos.y);
             sf::RectangleShape highlightRect(sf::Vector2f(boardParams.squareSize, boardParams.squareSize));
-            highlightRect.setPosition(boardParams.boardStartX + pos.x * boardParams.squareSize,
-                                      boardParams.boardStartY + pos.y * boardParams.squareSize);
+            highlightRect.setPosition(squarePos);
             highlightRect.setFillColor(sf::Color(255, 255, 0, 120));
             window.draw(highlightRect);
         }
@@ -1280,28 +1280,33 @@ int main()
                     Piece* piece = square.getPiece();
                     auto texIt = pieceTextures.find(piece->getTypeName());
                     if (texIt != pieceTextures.end()) {
+                        sf::Vector2f piecePos = graphicsManager.boardToGame(x, y);
                         sf::Sprite spr(texIt->second);
-                        spr.setPosition(boardParams.boardStartX + x * boardParams.squareSize,
-                                        boardParams.boardStartY + y * boardParams.squareSize);
+                        spr.setPosition(piecePos);
                         
                         // Scale based on actual texture dimensions
                         sf::Vector2u textureSize = texIt->second.getSize();
                         float scaleX = boardParams.squareSize / static_cast<float>(textureSize.x);
                         float scaleY = boardParams.squareSize / static_cast<float>(textureSize.y);
-                        spr.setScale(scaleX, scaleY);
+                        if (piece->getSide() == PlayerSide::PLAYER_TWO) {
+                            spr.setOrigin(static_cast<float>(textureSize.x), 0.f);
+                            spr.setScale(-scaleX, scaleY);
+                        } else {
+                            spr.setScale(scaleX, scaleY);
+                        }
                         window.draw(spr);
                     }
 
                     // Render health bar
                     renderHealthBar(window, piece,
-                                    boardParams.boardStartX + x * boardParams.squareSize,
-                                    boardParams.boardStartY + y * boardParams.squareSize,
+                                    piecePos.x,
+                                    piecePos.y,
                                     boardParams.squareSize);
 
                     // Render attack value
                     renderAttackValue(window, piece,
-                                     boardParams.boardStartX + x * boardParams.squareSize,
-                                     boardParams.boardStartY + y * boardParams.squareSize,
+                                     piecePos.x,
+                                     piecePos.y,
                                      boardParams.squareSize);
                 }
             }
@@ -1319,12 +1324,17 @@ int main()
             if (texIt != pieceTextures.end()) {
                 sf::Sprite spr(texIt->second);
                 spr.setPosition(draggedPieceX, draggedPieceY);
-                
+
                 // Scale based on actual texture dimensions
                 sf::Vector2u textureSize = texIt->second.getSize();
                 float scaleX = boardParams.squareSize / static_cast<float>(textureSize.x);
                 float scaleY = boardParams.squareSize / static_cast<float>(textureSize.y);
-                spr.setScale(scaleX, scaleY);
+                if (draggedPiece->getSide() == PlayerSide::PLAYER_TWO) {
+                    spr.setOrigin(static_cast<float>(textureSize.x), 0.f);
+                    spr.setScale(-scaleX, scaleY);
+                } else {
+                    spr.setScale(scaleX, scaleY);
+                }
                 window.draw(spr);
             }
             

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1278,9 +1278,10 @@ int main()
                 const Square& square = board.getSquare(x, y);
                 if (!square.isEmpty()) {
                     Piece* piece = square.getPiece();
+                    sf::Vector2f piecePos = graphicsManager.boardToGame(x, y);
+                    
                     auto texIt = pieceTextures.find(piece->getTypeName());
                     if (texIt != pieceTextures.end()) {
-                        sf::Vector2f piecePos = graphicsManager.boardToGame(x, y);
                         sf::Sprite spr(texIt->second);
                         spr.setPosition(piecePos);
                         


### PR DESCRIPTION
## Summary
- rotate display so player 1 is on the left by adding boardToGame/gameToBoard helpers
- use boardToGame everywhere pieces and squares are positioned
- flip player two sprites horizontally when drawn

## Testing
- `cmake ..` *(fails: Missing item in X11_X11_LIB)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d15b5608322b1e5e35cc3abbb9f