### PR TITLE
Add multi-session support to server

### DIFF
--- a/src/CardPlayValidator.cpp
+++ b/src/CardPlayValidator.cpp
@@ -48,13 +48,11 @@ ValidationResult CardPlayValidator::validateTargetedCardPlay(const GameState& ga
     // First validate basic card play
     auto basicResult = validateCardPlay(gameState, player, handIndex);
     if (!basicResult.isValid) {
-        std::cout << "DEBUG: Basic card play validation failed: " << basicResult.errorMessage << std::endl;
         return basicResult;
     }
     
     // Check if target position is within bounds
     if (!isValidBoardPosition(targetPosition)) {
-        std::cout << "DEBUG: Target position out of bounds: (" << targetPosition.x << ", " << targetPosition.y << ")" << std::endl;
         return ValidationResult(false, ValidationError::INVALID_TARGET,
                               "Target position (" + std::to_string(targetPosition.x) + ", " + 
                               std::to_string(targetPosition.y) + ") is out of bounds");
@@ -64,41 +62,26 @@ ValidationResult CardPlayValidator::validateTargetedCardPlay(const GameState& ga
     const Hand& hand = gameState.getHand(player);
     const Card* card = hand.getCard(handIndex);
     
-    std::cout << "DEBUG: Validating card '" << card->getName() << "' (cost: " << card->getSteamCost() 
-              << ") at position (" << targetPosition.x << ", " << targetPosition.y << ") for player " 
-              << (player == PlayerSide::PLAYER_ONE ? "1" : "2") << std::endl;
-    std::cout << "DEBUG: Player steam: " << gameState.getSteam(player) << std::endl;
-    std::cout << "DEBUG: Card type: " << static_cast<int>(card->getCardType()) << " (0=PIECE_CARD, 1=EFFECT_CARD)" << std::endl;
+
     
     switch (card->getCardType()) {
         case CardType::PIECE_CARD: {
             const PieceCard* pieceCard = dynamic_cast<const PieceCard*>(card);
             if (!pieceCard) {
-                std::cout << "DEBUG: Failed to cast to PieceCard" << std::endl;
                 return ValidationResult(false, ValidationError::UNKNOWN_CARD_TYPE,
                                       "Failed to cast to PieceCard");
             }
-            auto result = validatePiecePlacement(gameState, player, pieceCard, targetPosition);
-            if (!result.isValid) {
-                std::cout << "DEBUG: Piece placement validation failed: " << result.errorMessage << std::endl;
-            }
-            return result;
+            return validatePiecePlacement(gameState, player, pieceCard, targetPosition);
         }
         case CardType::EFFECT_CARD: {
             const EffectCard* effectCard = dynamic_cast<const EffectCard*>(card);
             if (!effectCard) {
-                std::cout << "DEBUG: Failed to cast to EffectCard" << std::endl;
                 return ValidationResult(false, ValidationError::UNKNOWN_CARD_TYPE,
                                       "Failed to cast to EffectCard");
             }
-            auto result = validateEffectTarget(gameState, player, effectCard, targetPosition);
-            if (!result.isValid) {
-                std::cout << "DEBUG: Effect target validation failed: " << result.errorMessage << std::endl;
-            }
-            return result;
+            return validateEffectTarget(gameState, player, effectCard, targetPosition);
         }
         default:
-            std::cout << "DEBUG: Unknown card type for targeted play" << std::endl;
             return ValidationResult(false, ValidationError::UNKNOWN_CARD_TYPE,
                                   "Unknown card type for targeted play");
     }

--- a/src/GameInitializer.cpp
+++ b/src/GameInitializer.cpp
@@ -106,8 +106,9 @@ void GameInitializer::resetGameState(GameState& gameState) {
         gameState.switchActivePlayer();
     }
     
-    // Set game phase to draw phase
-    gameState.setGamePhase(GamePhase::DRAW);
+    // Start directly in PLAY phase so the first player can make moves
+    // The DRAW phase auto-advancement was causing issues with turn switching
+    gameState.setGamePhase(GamePhase::PLAY);
     
     // Set game result to in progress
     gameState.setGameResult(GameResult::IN_PROGRESS);
@@ -118,9 +119,6 @@ void GameInitializer::resetGameState(GameState& gameState) {
     // Reset steam for both players
     gameState.setSteam(PlayerSide::PLAYER_ONE, 0);
     gameState.setSteam(PlayerSide::PLAYER_TWO, 0);
-    
-    // Auto-advance from draw phase to action phase
-    gameState.nextPhase();
 }
 
 void GameInitializer::calculateInitialControl(GameState& gameState) {

--- a/src/GameRules.cpp
+++ b/src/GameRules.cpp
@@ -22,7 +22,7 @@ void GameRules::initializeGame(GameState& gameState) {
     
     // Set starting player
     gameState.setActivePlayer(PlayerSide::PLAYER_ONE);
-    gameState.setGamePhase(GamePhase::DRAW); // Start with draw phase
+    gameState.setGamePhase(GamePhase::PLAY); // Start directly in PLAY phase to match other initialization
     gameState.setGameResult(GameResult::IN_PROGRESS);
     
     // Don't auto-advance from draw phase - let the game flow handle this

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -5,6 +5,7 @@
 #include "CardPlayValidator.h" // For comprehensive card validation
 #include "TurnManager.h" // For ActionType enum
 #include <SFML/Network/Packet.hpp> // For sf::Packet
+#include <iostream> // For std::cout
 
 // GameState.h should have already included these.
 // GameBoard.h includes Square.h, etc.
@@ -70,7 +71,7 @@ void GameState::initializeNewGame() {
     
     // Set initial game state
     activePlayer = PlayerSide::PLAYER_ONE;
-    phase = GamePhase::DRAW; // Start with draw phase
+    phase = GamePhase::PLAY; // Start directly in PLAY phase to avoid auto-advancement issues
     result = GameResult::IN_PROGRESS;
     turnNumber = 1;
     
@@ -84,8 +85,7 @@ void GameState::initializeNewGame() {
     // Initialize card system
     initializeCardSystem();
     
-    // Auto-advance from draw phase to action phase
-    nextPhase();
+    // No need to call nextPhase() - start directly in PLAY phase where actions are allowed
     
     // TODO: Place initial pieces on the board (King for each player)
     // This will be implemented when we have the Piece class

--- a/src/PieceCard.cpp
+++ b/src/PieceCard.cpp
@@ -46,18 +46,15 @@ bool PieceCard::play(GameState& gameState, PlayerSide player) const {
 bool PieceCard::isValidPlacement(const GameState& gameState, PlayerSide player, const Position& position) const {
     const GameBoard& board = gameState.getBoard();
     
-    std::cout << "DEBUG: Checking piece placement for " << pieceType << " at (" << position.x << ", " << position.y 
-              << ") for player " << (player == PlayerSide::PLAYER_ONE ? "1" : "2") << std::endl;
+
     
     // Check if position is within board bounds
     if (position.x < 0 || position.x >= 8 || position.y < 0 || position.y >= 8) {
-        std::cout << "DEBUG: Position out of bounds" << std::endl;
         return false;
     }
     
     // Check if the square is empty
     if (!board.getSquare(position.x, position.y).isEmpty()) {
-        std::cout << "DEBUG: Square is not empty" << std::endl;
         return false;
     }
     
@@ -71,10 +68,7 @@ bool PieceCard::isValidPlacement(const GameState& gameState, PlayerSide player, 
         validTerritory = (position.y >= 0 && position.y <= 3);
     }
     
-    std::cout << "DEBUG: Territorial check - player " 
-              << (player == PlayerSide::PLAYER_ONE ? "1" : "2")
-              << " placing at row " << position.y
-              << ": " << (validTerritory ? "VALID" : "INVALID") << std::endl;
+
     
     return validTerritory;
 }
@@ -104,12 +98,10 @@ bool PieceCard::playAtPosition(GameState& gameState, PlayerSide player, const Po
     // Note: Steam cost is handled by the caller (CardPlayValidator::executeCardPlay)
     // Don't spend steam here to avoid double-spending
     
-    std::cout << "DEBUG: PieceCard::playAtPosition - Creating piece of type '" << pieceType 
-              << "' for card '" << name << "'" << std::endl;
+
     
     // Use the global piece factory to create the piece with proper stats and movement rules
     if (!Square::globalPieceFactory) {
-        std::cout << "DEBUG: No global piece factory available" << std::endl;
         return false;
     }
     
@@ -118,7 +110,6 @@ bool PieceCard::playAtPosition(GameState& gameState, PlayerSide player, const Po
         auto piece = Square::globalPieceFactory->createPiece(pieceType, player);
         
         if (!piece) {
-            std::cout << "DEBUG: Failed to create piece of type '" << pieceType << "'" << std::endl;
             return false;
         }
         
@@ -130,12 +121,10 @@ bool PieceCard::playAtPosition(GameState& gameState, PlayerSide player, const Po
         Square& square = board.getSquare(position.x, position.y);
         square.setPiece(std::move(piece));
         
-        std::cout << "DEBUG: Successfully created and placed piece of type '" << pieceType << "'" << std::endl;
         return true;
     } catch (...) {
         // If piece creation fails, return false
         // Note: Steam refund is handled by the caller if needed
-        std::cout << "DEBUG: Exception caught while creating piece of type '" << pieceType << "'" << std::endl;
         return false;
     }
 }

--- a/src/TurnManager.cpp
+++ b/src/TurnManager.cpp
@@ -89,28 +89,13 @@ void TurnManager::processPlayCardAction(int cardIndex, const Position& position,
         return;
     }
     
-    // Debug: Show hand information
     const Hand& hand = gameState.getHand(activePlayer);
-    std::cout << "DEBUG: Player " << (activePlayer == PlayerSide::PLAYER_ONE ? "1" : "2") 
-              << " hand size: " << hand.size() << ", trying to play card index: " << cardIndex << std::endl;
-    
-    for (size_t i = 0; i < hand.size(); ++i) {
-        const Card* card = hand.getCard(i);
-        if (card) {
-            std::cout << "DEBUG: Hand[" << i << "]: " << card->getName() 
-                      << " (cost: " << card->getSteamCost() << ")" << std::endl;
-        } else {
-            std::cout << "DEBUG: Hand[" << i << "]: NULL CARD" << std::endl;
-        }
-    }
     
     // Validate card index
     if (cardIndex < 0 || static_cast<size_t>(cardIndex) >= gameState.getHand(activePlayer).size()) {
-        std::cout << "DEBUG: Card index " << cardIndex << " is invalid for hand size " << hand.size() << std::endl;
         result.success = false;
         result.message = "Invalid card index";
     } else {
-        std::cout << "DEBUG: Card index " << cardIndex << " is valid, proceeding with card play" << std::endl;
         // Use GameState's playCardWithResult method which uses CardPlayValidator internally
         PlayResult playResult = gameState.playCardWithResult(activePlayer, static_cast<size_t>(cardIndex), position);
         

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,7 +171,7 @@ void printBoardState(const GameState& gameState, PlayerSide localPlayer = Player
     // Print local player's hand if specified
     if (localPlayer != PlayerSide::NEUTRAL) {
         const Hand& hand = gameState.getHand(localPlayer);
-        std::cout << "=== MY HAND DEBUG ===" << std::endl;
+
         std::cout << "My Hand (" << hand.size() << " cards, " 
                   << gameState.getSteam(localPlayer) << " steam):" << std::endl;
         for (size_t i = 0; i < hand.size(); ++i) {
@@ -1003,6 +1003,9 @@ int main()
             } else if (gameHasStarted && myPlayerSide == gameState.getActivePlayer()) {
                 // Only handle input if it's the player's turn
                 inputManager.handleEvent(event);
+            } else if (gameHasStarted) {
+                // Debug: Log when input is blocked
+                
             }
         }
 
@@ -1095,6 +1098,7 @@ int main()
                             if (receivedPacket >> gameState) { // Deserialize the updated GameState
                                 // uiMessage = (myPlayerSide == gameState.getActivePlayer() ? "Your turn" : "Opponent's turn");
                                 std::cout << "GameState updated. Turn: " << gameState.getTurnNumber() << std::endl;
+
                                 printBoardState(gameState, myPlayerSide);
                                 
                                 // Update local player steam display

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -425,6 +425,12 @@ void handle_client(std::shared_ptr<ClientConnection> client) {
                               << " at (" << cardPlayData.targetX << ", " << cardPlayData.targetY 
                               << ") from " << client->socket.getRemoteAddress() << std::endl;
                     
+                    auto session = client->session.lock();
+                    if (!session) {
+                        sendCardPlayRejection(client, "Not in a game");
+                        continue;
+                    }
+                    
                     // Verify it's the client's turn
                     if (client->playerSide != session->gameState.getActivePlayer()) {
                         sendCardPlayRejection(client, "Not your turn");

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -92,7 +92,7 @@ Move reconstructMoveWithPiece(const Move& clientMove, const GameState& gameState
 // Helper function to broadcast game state to all connected clients
 // Helper function to print card hands for debugging
 void printCardHands(const GameState& gameState) {
-    std::cout << "=== CARD HANDS DEBUG ===" << std::endl;
+    
     
     // Player 1 hand
     const Hand& p1Hand = gameState.getHand(PlayerSide::PLAYER_ONE);
@@ -186,6 +186,23 @@ void tryStartMatchmaking() {
         matchmakers[0]->playerSide = PlayerSide::PLAYER_ONE;
         matchmakers[1]->playerSide = PlayerSide::PLAYER_TWO;
         
+        // Send PlayerAssignment messages to inform clients of their sides
+        sf::Packet assignment1;
+        assignment1 << MessageType::PlayerAssignment << matchmakers[0]->playerSide;
+        if (matchmakers[0]->socket.send(assignment1) != sf::Socket::Done) {
+            std::cerr << "Error sending PlayerAssignment to " << matchmakers[0]->username << std::endl;
+        } else {
+            std::cout << "PlayerAssignment sent to " << matchmakers[0]->username << " (PLAYER_ONE)" << std::endl;
+        }
+        
+        sf::Packet assignment2;
+        assignment2 << MessageType::PlayerAssignment << matchmakers[1]->playerSide;
+        if (matchmakers[1]->socket.send(assignment2) != sf::Socket::Done) {
+            std::cerr << "Error sending PlayerAssignment to " << matchmakers[1]->username << std::endl;
+        } else {
+            std::cout << "PlayerAssignment sent to " << matchmakers[1]->username << " (PLAYER_TWO)" << std::endl;
+        }
+        
         // Clear their matchmaking flags
         matchmakers[0]->lookingForMatch = false;
         matchmakers[1]->lookingForMatch = false;
@@ -205,7 +222,7 @@ void tryStartMatchmaking() {
         matchmakers[1]->session = session;
 
         // Debug: Print board state after initialization
-        std::cout << "DEBUG: Board state after initialization:" << std::endl;
+
         const GameBoard& board = session->gameState.getBoard();
         for (int y = 0; y < GameBoard::BOARD_SIZE; y++) {
             std::cout << y << " | ";
@@ -313,6 +330,8 @@ void handle_client(std::shared_ptr<ClientConnection> client) {
                         continue;
                     }
 
+
+
                     // Process the move using TurnManager
                     if (session->turnManager) {
                         bool moveProcessed = false;
@@ -324,6 +343,7 @@ void handle_client(std::shared_ptr<ClientConnection> client) {
                             
                             if (result.success) {
                                 std::cout << "Move processed successfully: " << result.message << std::endl;
+                                
                                 // Broadcast updated game state to all clients
                                 broadcastGameState(session);
 

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -1,744 +1,751 @@
 {
-  "tasks": [
-    {
-      "id": 1,
-      "title": "Setup C++20 Project with CMake and SFML",
-      "description": "Initialize the project repository with C++20, CMake build system, and SFML integration for graphics and input handling.",
-      "details": "1. Create a new C++ project with CMake\n2. Configure CMake to use C++20 standard\n3. Integrate SFML library for graphics and input handling\n4. Setup basic project structure with directories for source, headers, assets, and tests\n5. Create a simple window application to verify SFML integration\n6. Setup Git repository with appropriate .gitignore\n\nCMakeLists.txt example:\n```cmake\ncmake_minimum_required(VERSION 3.16)\nproject(BayouBonanza VERSION 0.1.0)\n\n# C++20 standard\nset(CMAKE_CXX_STANDARD 20)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\n\n# Find SFML packages\nfind_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)\n\n# Include directories\ninclude_directories(include)\n\n# Add executable\nadd_executable(BayouBonanza src/main.cpp)\n\n# Link libraries\ntarget_link_libraries(BayouBonanza sfml-graphics sfml-window sfml-system)\n```",
-      "testStrategy": "1. Verify that the project builds successfully with CMake\n2. Ensure SFML window opens and displays correctly\n3. Confirm that input events are properly captured\n4. Test on Windows platform to ensure compatibility",
-      "priority": "high",
-      "dependencies": [],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Install necessary tools",
-          "description": "Install C++20 compatible compiler, CMake, and SFML library",
-          "dependencies": [],
-          "details": "1. Install a C++20 compatible compiler (e.g., GCC 10+ or Clang 10+)\n2. Install CMake (version 3.16 or higher)\n3. Download and install SFML library (version 2.5.1 or higher)",
-          "status": "done"
-        },
-        {
-          "id": 2,
-          "title": "Set up project directory structure",
-          "description": "Create the basic directory structure for the C++20 project",
-          "dependencies": [
-            1
-          ],
-          "details": "1. Create a root project directory\n2. Create subdirectories: 'src' for source files, 'include' for header files, 'lib' for libraries, and 'build' for CMake output",
-          "status": "done"
-        },
-        {
-          "id": 3,
-          "title": "Configure CMakeLists.txt",
-          "description": "Create and configure the main CMakeLists.txt file for the project",
-          "dependencies": [
-            2
-          ],
-          "details": "1. Set minimum CMake version\n2. Define project name and language\n3. Set C++ standard to C++20\n4. Add SFML dependency\n5. Set include directories\n6. Add executable and link libraries",
-          "status": "done"
-        },
-        {
-          "id": 4,
-          "title": "Create initial C++ source files",
-          "description": "Set up basic C++ source files for the project",
-          "dependencies": [
-            2
-          ],
-          "details": "1. Create a main.cpp file in the 'src' directory\n2. Implement a basic SFML window creation in main.cpp\n3. Create additional header files in 'include' directory if needed",
-          "status": "done"
-        },
-        {
-          "id": 5,
-          "title": "Generate build files",
-          "description": "Use CMake to generate build files for the project",
-          "dependencies": [
-            3,
-            4
-          ],
-          "details": "1. Navigate to the 'build' directory\n2. Run CMake command to generate build files\n3. Verify that build files are created successfully",
-          "status": "done"
-        },
-        {
-          "id": 6,
-          "title": "Build and run the project",
-          "description": "Compile the project and run the executable",
-          "dependencies": [
-            5
-          ],
-          "details": "1. Use generated build files to compile the project\n2. Locate the compiled executable\n3. Run the executable and verify SFML window appears\n4. Test for any runtime errors or issues",
-          "status": "done"
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "title": "Implement Core Game Engine and Board Representation",
-      "description": "Create the foundational game engine with chess-like board representation and basic game state management.",
-      "details": "1. Define the game board as an 8x8 grid\n2. Implement board representation using a 2D array or vector\n3. Create enums for piece types, player sides, and square states\n4. Implement basic game state class to track board state, active player, and game phase\n5. Create methods for board initialization and reset\n\nPseudo-code for board representation:\n```cpp\nclass GameBoard {\nprivate:\n    std::array<std::array<Square, 8>, 8> board;\n    \npublic:\n    GameBoard();\n    Square& getSquare(int x, int y);\n    bool isValidPosition(int x, int y) const;\n    void resetBoard();\n    // Additional methods for board manipulation\n};\n\nclass Square {\nprivate:\n    Piece* piece; // nullptr if empty\n    int controlValuePlayer1;\n    int controlValuePlayer2;\n    \npublic:\n    Square();\n    bool isEmpty() const;\n    Piece* getPiece() const;\n    void setPiece(Piece* piece);\n    int getControlValue(PlayerSide side) const;\n    void setControlValue(PlayerSide side, int value);\n};\n```",
-      "testStrategy": "1. Unit tests for board initialization and reset\n2. Verify correct dimensions and indexing of the board\n3. Test boundary conditions for board access\n4. Validate game state transitions\n5. Ensure proper tracking of board state",
-      "priority": "high",
-      "dependencies": [
-        1
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Design Board Representation",
-          "description": "Create a data structure to represent the game board",
-          "dependencies": [],
-          "details": "Implement a 2D array or matrix to represent the game board. Define methods for accessing and modifying board cells.",
-          "status": "done"
-        },
-        {
-          "id": 2,
-          "title": "Implement Game State Class",
-          "description": "Create a class to manage the overall game state",
-          "dependencies": [
-            1
-          ],
-          "details": "Design a GameState class that includes the board, current player, score, and other relevant game information. Implement methods for updating and querying the game state.",
-          "status": "done"
-        },
-        {
-          "id": 3,
-          "title": "Develop Move Validation Logic",
-          "description": "Implement logic to validate player moves",
-          "dependencies": [
-            1,
-            2
-          ],
-          "details": "Create methods to check if a move is legal based on the current game state and board configuration. Include checks for piece placement, capture rules, and any special move conditions.",
-          "status": "done"
-        },
-        {
-          "id": 4,
-          "title": "Implement Move Execution",
-          "description": "Create methods to execute valid moves and update the game state",
-          "dependencies": [
-            2,
-            3
-          ],
-          "details": "Develop functions to apply a validated move to the game state, updating the board, player turns, and any other affected game elements.",
-          "status": "done"
-        },
-        {
-          "id": 5,
-          "title": "Design Game Rules Engine",
-          "description": "Implement the core game rules and logic",
-          "dependencies": [
-            2,
-            3,
-            4
-          ],
-          "details": "Create a Rules class that encapsulates the game's rules, including win conditions, draw conditions, and any special game mechanics.",
-          "status": "done"
-        },
-        {
-          "id": 6,
-          "title": "Implement Turn Management",
-          "description": "Create a system to manage player turns and game flow",
-          "dependencies": [
-            2,
-            4,
-            5
-          ],
-          "details": "Develop methods to handle turn transitions, including any special actions that occur at the beginning or end of a turn.",
-          "status": "done"
-        },
-        {
-          "id": 7,
-          "title": "Create Game Initialization Logic",
-          "description": "Implement methods to set up a new game",
-          "dependencies": [
-            1,
-            2
-          ],
-          "details": "Develop functions to initialize the game board, set up initial piece positions, and establish the starting game state.",
-          "status": "done"
-        },
-        {
-          "id": 8,
-          "title": "Implement Game Over Detection",
-          "description": "Create logic to detect when the game has ended",
-          "dependencies": [
-            2,
-            5
-          ],
-          "details": "Develop methods to check for win conditions, draw conditions, or any other game-ending scenarios after each move or turn.",
-          "status": "done"
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "title": "Implement Piece Class Hierarchy and Movement System",
-      "description": "Design and implement the piece class hierarchy with attributes for health, attack, and movement patterns.",
-      "details": "1. Create a base Piece class with common attributes (health, attack, owner)\n2. Implement derived classes for different piece types (King, etc.)\n3. Define movement patterns for each piece type\n4. Implement methods to calculate valid moves\n5. Create system for executing moves and updating board state\n\nPseudo-code for piece hierarchy:\n```cpp\nclass Piece {\nprotected:\n    PlayerSide owner;\n    int health;\n    int attack;\n    std::string name;\n    \npublic:\n    Piece(PlayerSide owner, int health, int attack, std::string name);\n    virtual ~Piece() = default;\n    \n    PlayerSide getOwner() const;\n    int getHealth() const;\n    int getAttack() const;\n    std::string getName() const;\n    \n    void takeDamage(int amount);\n    bool isAlive() const;\n    \n    virtual std::vector<Position> getValidMoves(const GameBoard& board, Position currentPos) = 0;\n    virtual void executeMove(GameBoard& board, Position from, Position to) = 0;\n};\n\nclass King : public Piece {\npublic:\n    King(PlayerSide owner);\n    std::vector<Position> getValidMoves(const GameBoard& board, Position currentPos) override;\n    void executeMove(GameBoard& board, Position from, Position to) override;\n};\n```",
-      "testStrategy": "1. Unit tests for each piece type's movement patterns\n2. Verify health and attack mechanics\n3. Test boundary conditions for movement\n4. Validate piece interactions\n5. Ensure proper owner assignment and identification",
-      "priority": "high",
-      "dependencies": [
-        2
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Design the Piece base class",
-          "description": "Create the abstract Piece base class with common properties and virtual methods",
-          "dependencies": [],
-          "details": "Implement the Piece base class with: color property (white/black), position property (coordinates), isAlive flag, abstract move validation method, abstract movement pattern generation method, capture logic, and first-move tracking for relevant pieces. Include a virtual method for getting all possible moves and a method to check if a move is valid.",
-          "status": "done"
-        },
-        {
-          "id": 2,
-          "title": "Implement concrete piece classes",
-          "description": "Create derived classes for each chess piece type with specific movement patterns",
-          "dependencies": [
-            1
-          ],
-                      "details": "Implement classes for Pawn, Sweetykins, Knight, Bishop, Queen, and King. Each class should override the movement validation methods with piece-specific logic. Include special rules like castling for King, en passant for Pawn, and diagonal/straight line movement for Bishop/Sweetykins. Ensure each piece correctly calculates its possible moves based on the current board state.",
-          "status": "done"
-        },
-        {
-          "id": 3,
-          "title": "Develop movement pattern algorithms",
-          "description": "Create algorithms to calculate valid moves for each piece type",
-          "dependencies": [
-            1,
-            2
-          ],
+  "master": {
+    "tasks": [
+      {
+        "id": 1,
+        "title": "Setup C++20 Project with CMake and SFML",
+        "description": "Initialize the project repository with C++20, CMake build system, and SFML integration for graphics and input handling.",
+        "details": "1. Create a new C++ project with CMake\n2. Configure CMake to use C++20 standard\n3. Integrate SFML library for graphics and input handling\n4. Setup basic project structure with directories for source, headers, assets, and tests\n5. Create a simple window application to verify SFML integration\n6. Setup Git repository with appropriate .gitignore\n\nCMakeLists.txt example:\n```cmake\ncmake_minimum_required(VERSION 3.16)\nproject(BayouBonanza VERSION 0.1.0)\n\n# C++20 standard\nset(CMAKE_CXX_STANDARD 20)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\n\n# Find SFML packages\nfind_package(SFML 2.5 COMPONENTS graphics window system REQUIRED)\n\n# Include directories\ninclude_directories(include)\n\n# Add executable\nadd_executable(BayouBonanza src/main.cpp)\n\n# Link libraries\ntarget_link_libraries(BayouBonanza sfml-graphics sfml-window sfml-system)\n```",
+        "testStrategy": "1. Verify that the project builds successfully with CMake\n2. Ensure SFML window opens and displays correctly\n3. Confirm that input events are properly captured\n4. Test on Windows platform to ensure compatibility",
+        "priority": "high",
+        "dependencies": [],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Install necessary tools",
+            "description": "Install C++20 compatible compiler, CMake, and SFML library",
+            "dependencies": [],
+            "details": "1. Install a C++20 compatible compiler (e.g., GCC 10+ or Clang 10+)\n2. Install CMake (version 3.16 or higher)\n3. Download and install SFML library (version 2.5.1 or higher)",
+            "status": "done"
+          },
+          {
+            "id": 2,
+            "title": "Set up project directory structure",
+            "description": "Create the basic directory structure for the C++20 project",
+            "dependencies": [
+              1
+            ],
+            "details": "1. Create a root project directory\n2. Create subdirectories: 'src' for source files, 'include' for header files, 'lib' for libraries, and 'build' for CMake output",
+            "status": "done"
+          },
+          {
+            "id": 3,
+            "title": "Configure CMakeLists.txt",
+            "description": "Create and configure the main CMakeLists.txt file for the project",
+            "dependencies": [
+              2
+            ],
+            "details": "1. Set minimum CMake version\n2. Define project name and language\n3. Set C++ standard to C++20\n4. Add SFML dependency\n5. Set include directories\n6. Add executable and link libraries",
+            "status": "done"
+          },
+          {
+            "id": 4,
+            "title": "Create initial C++ source files",
+            "description": "Set up basic C++ source files for the project",
+            "dependencies": [
+              2
+            ],
+            "details": "1. Create a main.cpp file in the 'src' directory\n2. Implement a basic SFML window creation in main.cpp\n3. Create additional header files in 'include' directory if needed",
+            "status": "done"
+          },
+          {
+            "id": 5,
+            "title": "Generate build files",
+            "description": "Use CMake to generate build files for the project",
+            "dependencies": [
+              3,
+              4
+            ],
+            "details": "1. Navigate to the 'build' directory\n2. Run CMake command to generate build files\n3. Verify that build files are created successfully",
+            "status": "done"
+          },
+          {
+            "id": 6,
+            "title": "Build and run the project",
+            "description": "Compile the project and run the executable",
+            "dependencies": [
+              5
+            ],
+            "details": "1. Use generated build files to compile the project\n2. Locate the compiled executable\n3. Run the executable and verify SFML window appears\n4. Test for any runtime errors or issues",
+            "status": "done"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Implement Core Game Engine and Board Representation",
+        "description": "Create the foundational game engine with chess-like board representation and basic game state management.",
+        "details": "1. Define the game board as an 8x8 grid\n2. Implement board representation using a 2D array or vector\n3. Create enums for piece types, player sides, and square states\n4. Implement basic game state class to track board state, active player, and game phase\n5. Create methods for board initialization and reset\n\nPseudo-code for board representation:\n```cpp\nclass GameBoard {\nprivate:\n    std::array<std::array<Square, 8>, 8> board;\n    \npublic:\n    GameBoard();\n    Square& getSquare(int x, int y);\n    bool isValidPosition(int x, int y) const;\n    void resetBoard();\n    // Additional methods for board manipulation\n};\n\nclass Square {\nprivate:\n    Piece* piece; // nullptr if empty\n    int controlValuePlayer1;\n    int controlValuePlayer2;\n    \npublic:\n    Square();\n    bool isEmpty() const;\n    Piece* getPiece() const;\n    void setPiece(Piece* piece);\n    int getControlValue(PlayerSide side) const;\n    void setControlValue(PlayerSide side, int value);\n};\n```",
+        "testStrategy": "1. Unit tests for board initialization and reset\n2. Verify correct dimensions and indexing of the board\n3. Test boundary conditions for board access\n4. Validate game state transitions\n5. Ensure proper tracking of board state",
+        "priority": "high",
+        "dependencies": [
+          1
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Design Board Representation",
+            "description": "Create a data structure to represent the game board",
+            "dependencies": [],
+            "details": "Implement a 2D array or matrix to represent the game board. Define methods for accessing and modifying board cells.",
+            "status": "done"
+          },
+          {
+            "id": 2,
+            "title": "Implement Game State Class",
+            "description": "Create a class to manage the overall game state",
+            "dependencies": [
+              1
+            ],
+            "details": "Design a GameState class that includes the board, current player, score, and other relevant game information. Implement methods for updating and querying the game state.",
+            "status": "done"
+          },
+          {
+            "id": 3,
+            "title": "Develop Move Validation Logic",
+            "description": "Implement logic to validate player moves",
+            "dependencies": [
+              1,
+              2
+            ],
+            "details": "Create methods to check if a move is legal based on the current game state and board configuration. Include checks for piece placement, capture rules, and any special move conditions.",
+            "status": "done"
+          },
+          {
+            "id": 4,
+            "title": "Implement Move Execution",
+            "description": "Create methods to execute valid moves and update the game state",
+            "dependencies": [
+              2,
+              3
+            ],
+            "details": "Develop functions to apply a validated move to the game state, updating the board, player turns, and any other affected game elements.",
+            "status": "done"
+          },
+          {
+            "id": 5,
+            "title": "Design Game Rules Engine",
+            "description": "Implement the core game rules and logic",
+            "dependencies": [
+              2,
+              3,
+              4
+            ],
+            "details": "Create a Rules class that encapsulates the game's rules, including win conditions, draw conditions, and any special game mechanics.",
+            "status": "done"
+          },
+          {
+            "id": 6,
+            "title": "Implement Turn Management",
+            "description": "Create a system to manage player turns and game flow",
+            "dependencies": [
+              2,
+              4,
+              5
+            ],
+            "details": "Develop methods to handle turn transitions, including any special actions that occur at the beginning or end of a turn.",
+            "status": "done"
+          },
+          {
+            "id": 7,
+            "title": "Create Game Initialization Logic",
+            "description": "Implement methods to set up a new game",
+            "dependencies": [
+              1,
+              2
+            ],
+            "details": "Develop functions to initialize the game board, set up initial piece positions, and establish the starting game state.",
+            "status": "done"
+          },
+          {
+            "id": 8,
+            "title": "Implement Game Over Detection",
+            "description": "Create logic to detect when the game has ended",
+            "dependencies": [
+              2,
+              5
+            ],
+            "details": "Develop methods to check for win conditions, draw conditions, or any other game-ending scenarios after each move or turn.",
+            "status": "done"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Implement Piece Class Hierarchy and Movement System",
+        "description": "Design and implement the piece class hierarchy with attributes for health, attack, and movement patterns.",
+        "details": "1. Create a base Piece class with common attributes (health, attack, owner)\n2. Implement derived classes for different piece types (King, etc.)\n3. Define movement patterns for each piece type\n4. Implement methods to calculate valid moves\n5. Create system for executing moves and updating board state\n\nPseudo-code for piece hierarchy:\n```cpp\nclass Piece {\nprotected:\n    PlayerSide owner;\n    int health;\n    int attack;\n    std::string name;\n    \npublic:\n    Piece(PlayerSide owner, int health, int attack, std::string name);\n    virtual ~Piece() = default;\n    \n    PlayerSide getOwner() const;\n    int getHealth() const;\n    int getAttack() const;\n    std::string getName() const;\n    \n    void takeDamage(int amount);\n    bool isAlive() const;\n    \n    virtual std::vector<Position> getValidMoves(const GameBoard& board, Position currentPos) = 0;\n    virtual void executeMove(GameBoard& board, Position from, Position to) = 0;\n};\n\nclass King : public Piece {\npublic:\n    King(PlayerSide owner);\n    std::vector<Position> getValidMoves(const GameBoard& board, Position currentPos) override;\n    void executeMove(GameBoard& board, Position from, Position to) override;\n};\n```",
+        "testStrategy": "1. Unit tests for each piece type's movement patterns\n2. Verify health and attack mechanics\n3. Test boundary conditions for movement\n4. Validate piece interactions\n5. Ensure proper owner assignment and identification",
+        "priority": "high",
+        "dependencies": [
+          2
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Design the Piece base class",
+            "description": "Create the abstract Piece base class with common properties and virtual methods",
+            "dependencies": [],
+            "details": "Implement the Piece base class with: color property (white/black), position property (coordinates), isAlive flag, abstract move validation method, abstract movement pattern generation method, capture logic, and first-move tracking for relevant pieces. Include a virtual method for getting all possible moves and a method to check if a move is valid.",
+            "status": "done"
+          },
+          {
+            "id": 2,
+            "title": "Implement concrete piece classes",
+            "description": "Create derived classes for each chess piece type with specific movement patterns",
+            "dependencies": [
+              1
+            ],
+            "details": "Implement classes for Pawn, Sweetykins, Knight, Bishop, Queen, and King. Each class should override the movement validation methods with piece-specific logic. Include special rules like castling for King, en passant for Pawn, and diagonal/straight line movement for Bishop/Sweetykins. Ensure each piece correctly calculates its possible moves based on the current board state.",
+            "status": "done"
+          },
+          {
+            "id": 3,
+            "title": "Develop movement pattern algorithms",
+            "description": "Create algorithms to calculate valid moves for each piece type",
+            "dependencies": [
+              1,
+              2
+            ],
             "details": "Implement algorithms for: straight line movement (Sweetykins, Queen), diagonal movement (Bishop, Queen), L-shaped movement (Knight), single square movement plus castling (King), and forward movement plus diagonal capture (Pawn). Include obstacle detection to prevent pieces from moving through other pieces and boundary checking to keep pieces on the board.",
-          "status": "done"
-        },
-        {
-          "id": 4,
-          "title": "Integrate with game board",
-          "description": "Connect piece movement system with the game board representation",
-          "dependencies": [
-            2,
-            3
-          ],
-          "details": "Create methods to: update the board when pieces move, handle piece capture, validate moves against the current board state, and check for special conditions like check and checkmate. Implement a system to query the board for piece positions to use in movement validation. Ensure pieces can access board state to determine valid moves.",
-          "status": "done"
-        },
-        {
-          "id": 5,
-          "title": "Implement move execution and validation system",
-          "description": "Create a system to execute moves and validate their legality",
-          "dependencies": [
-            3,
-            4
-          ],
-          "details": "Develop a move execution system that: validates moves before execution, handles the actual movement of pieces on the board, manages piece capture, implements special moves (castling, en passant, promotion), and ensures a player cannot make moves that leave their king in check. Include a method to generate all legal moves for a given player.",
-          "status": "done"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Implement Combat System",
-      "description": "Create the combat system for pieces to attack and damage each other, including health tracking and piece removal.",
-      "details": "1. Implement attack mechanics between pieces\n2. Create damage calculation system\n3. Implement health tracking and piece death\n4. Handle piece removal from board\n5. Implement combat resolution logic\n\nPseudo-code for combat system:\n```cpp\nclass CombatSystem {\npublic:\n    static void resolveCombat(GameBoard& board, Position attacker, Position defender);\n    static void applyDamage(Piece* attacker, Piece* defender);\n    static void checkAndRemoveDeadPieces(GameBoard& board);\n};\n\nvoid CombatSystem::resolveCombat(GameBoard& board, Position attacker, Position defender) {\n    Piece* attackingPiece = board.getSquare(attacker.x, attacker.y).getPiece();\n    Piece* defendingPiece = board.getSquare(defender.x, defender.y).getPiece();\n    \n    if (attackingPiece && defendingPiece && \n        attackingPiece->getOwner() != defendingPiece->getOwner()) {\n        applyDamage(attackingPiece, defendingPiece);\n        checkAndRemoveDeadPieces(board);\n    }\n}\n```",
-      "testStrategy": "1. Unit tests for damage calculation\n2. Verify piece death and removal\n3. Test various combat scenarios\n4. Validate king death detection\n5. Ensure proper combat resolution order",
-      "priority": "high",
-      "dependencies": [
-        3
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Design combat data structures",
-          "description": "Create the necessary data structures to track combat-related information such as piece health, attack values, and combat status.",
-          "dependencies": [],
-          "details": "Define classes or interfaces for combat attributes (health, attack power, defense). Implement health tracking for each piece on the board. Create a system to track combat history for potential undo/replay features. Ensure these structures integrate with the existing piece representation.",
-          "status": "done"
-        },
-        {
-          "id": 2,
-          "title": "Implement damage calculation logic",
-          "description": "Create the core algorithm for calculating damage during combat encounters between pieces.",
-          "dependencies": [
-            1
-          ],
-          "details": "Develop formulas for attack and defense calculations. Implement modifiers based on piece types or special abilities. Create random elements if needed (critical hits, miss chance). Include logic for environmental or positional bonuses/penalties. Add methods to apply calculated damage to pieces.",
-          "status": "done"
-        },
-        {
-          "id": 3,
-          "title": "Develop health tracking system",
-          "description": "Build a system to monitor and update the health status of pieces during and after combat.",
-          "dependencies": [
-            1,
-            2
-          ],
-          "details": "Implement methods to reduce health based on damage taken. Create visual indicators for current health status. Add logic to detect when health reaches zero or critical levels. Implement any healing or regeneration mechanics if applicable. Ensure health changes trigger appropriate UI updates.",
-          "status": "done"
-        },
-        {
-          "id": 4,
-          "title": "Create piece removal logic",
-          "description": "Implement the system for removing pieces from the board when they are defeated in combat.",
-          "dependencies": [
-            3
-          ],
-          "details": "Develop logic to detect when a piece should be removed (health <= 0). Create methods to safely remove pieces from the game board. Implement any death effects or consequences. Handle cleanup of references to removed pieces. Add animations or visual feedback for piece removal.",
-          "status": "done"
-        },
-        {
-          "id": 5,
-          "title": "Integrate combat system with game board state",
-          "description": "Connect the combat system with the overall game state to ensure proper interaction with other game systems.",
-          "dependencies": [
-            2,
-            3,
-            4
-          ],
-          "details": "Implement combat initiation based on game rules (adjacent pieces, attack commands). Create event system for combat-related events (attack, damage, defeat). Update game state after combat resolution. Ensure combat results affect turn progression appropriately. Add combat logs or history tracking for player information.",
-          "status": "done"
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "title": "Implement Influence and Control System",
-      "description": "Create the system for calculating piece influence on adjacent squares and determining square control.",
-      "details": "1. Implement influence calculation for each piece type\n2. Create system to propagate influence to adjacent squares\n3. Implement control determination based on influence values\n4. Update control values when pieces move or are removed\n5. Optimize influence calculation for performance\n\nPseudo-code for influence system:\n```cpp\nclass InfluenceSystem {\npublic:\n    static void calculateBoardInfluence(GameBoard& board);\n    static void calculatePieceInfluence(GameBoard& board, Position piecePos);\n    static void determineSquareControl(GameBoard& board);\n    static PlayerSide getControllingPlayer(const Square& square);\n};\n\nvoid InfluenceSystem::calculateBoardInfluence(GameBoard& board) {\n    // Reset all influence values\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            board.getSquare(x, y).setControlValue(PlayerSide::PLAYER_1, 0);\n            board.getSquare(x, y).setControlValue(PlayerSide::PLAYER_2, 0);\n        }\n    }\n    \n    // Calculate influence for each piece\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            if (!board.getSquare(x, y).isEmpty()) {\n                calculatePieceInfluence(board, Position{x, y});\n            }\n        }\n    }\n    \n    determineSquareControl(board);\n}\n```",
-      "testStrategy": "1. Unit tests for influence calculation\n2. Verify control determination logic\n3. Test influence propagation\n4. Benchmark performance for large board states\n5. Validate control changes after piece movement",
-      "priority": "high",
-      "dependencies": [
-        3
-      ],
-      "status": "done",
-      "subtasks": []
-    },
-    {
-      "id": 6,
-      "title": "Implement Steam Resource Generation System",
-      "description": "Create the system for generating and managing the 'Steam' resource based on controlled squares.",
-      "details": "1. Implement steam resource tracking for each player\n2. Create system to calculate steam generation based on controlled squares\n3. Implement steam accumulation per turn\n4. Create methods for spending steam\n5. Implement UI indicators for steam resources\n\nPseudo-code for steam resource system:\n```cpp\nclass ResourceSystem {\nprivate:\n    int player1Steam;\n    int player2Steam;\n    \npublic:\n    ResourceSystem();\n    \n    int getSteam(PlayerSide player) const;\n    void setSteam(PlayerSide player, int amount);\n    void addSteam(PlayerSide player, int amount);\n    bool spendSteam(PlayerSide player, int amount);\n    \n    void calculateSteamGeneration(const GameBoard& board);\n    void processTurnStart(PlayerSide activePlayer, const GameBoard& board);\n};\n\nvoid ResourceSystem::calculateSteamGeneration(const GameBoard& board) {\n    int player1Generation = 0;\n    int player2Generation = 0;\n    \n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            PlayerSide controller = InfluenceSystem::getControllingPlayer(square);\n            \n            if (controller == PlayerSide::PLAYER_1) {\n                player1Generation++;\n            } else if (controller == PlayerSide::PLAYER_2) {\n                player2Generation++;\n            }\n        }\n    }\n    \n    // Store generation values for use in processTurnStart\n}\n```",
-      "testStrategy": "1. Unit tests for steam calculation\n2. Verify steam accumulation per turn\n3. Test steam spending mechanics\n4. Validate resource updates based on board control changes\n5. Ensure proper resource limits and constraints",
-      "priority": "medium",
-      "dependencies": [
-        5
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Create ResourceSystem Class Structure",
-          "description": "Design and implement the basic ResourceSystem class with steam tracking for both players",
-          "details": "1. Create ResourceSystem.h header file\\n2. Define private member variables for player1Steam and player2Steam\\n3. Implement constructor to initialize steam values\\n4. Add getter methods: getSteam(PlayerSide player)\\n5. Add setter methods: setSteam(PlayerSide player, int amount)\\n6. Add utility methods: addSteam() and spendSteam()\\n7. Include proper error checking for negative values",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 6
-        },
-        {
-          "id": 2,
-          "title": "Implement Steam Generation Calculation",
-          "description": "Create the logic to calculate steam generation based on controlled squares using the InfluenceSystem",
-          "details": "1. Implement calculateSteamGeneration(const GameBoard& board) method\\n2. Iterate through all board squares (8x8 grid)\\n3. Use InfluenceSystem::getControllingPlayer() to determine square control\\n4. Count controlled squares for each player\\n5. Store generation values for use in turn processing\\n6. Add configurable steam generation rates if needed",
-          "status": "done",
-          "dependencies": [
-            1
-          ],
-          "parentTaskId": 6
-        },
-        {
-          "id": 3,
-          "title": "Implement Turn-Based Steam Processing",
-          "description": "Create the processTurnStart method to add generated steam to players at the beginning of their turn",
-          "details": "1. Implement processTurnStart(PlayerSide activePlayer, const GameBoard& board) method\\n2. Call calculateSteamGeneration() to get current generation values\\n3. Add generated steam to the active player's total\\n4. Ensure steam accumulation is properly tracked\\n5. Add logging/debugging output for steam generation\\n6. Handle edge cases like maximum steam limits if applicable",
-          "status": "done",
-          "dependencies": [
-            2
-          ],
-          "parentTaskId": 6
-        },
-        {
-          "id": 4,
-          "title": "Integrate ResourceSystem with Game Engine",
-          "description": "Connect the ResourceSystem with the existing game engine components and ensure proper integration",
-          "details": "1. Add ResourceSystem as a member to GameState or GameBoard class\\n2. Update existing game loop to call processTurnStart() at turn beginning\\n3. Ensure ResourceSystem is properly initialized in game setup\\n4. Add methods to query steam values from other game systems\\n5. Update any existing placeholder resource code\\n6. Test integration with existing piece and board systems",
-          "status": "done",
-          "dependencies": [
-            3
-          ],
-          "parentTaskId": 6
-        },
-        {
-          "id": 5,
-          "title": "Create Unit Tests for ResourceSystem",
-          "description": "Implement comprehensive unit tests to verify steam calculation, accumulation, and spending mechanics",
-          "details": "1. Create test file for ResourceSystem (test_ResourceSystem.cpp)\\n2. Test basic steam getter/setter functionality\\n3. Test steam spending with sufficient and insufficient funds\\n4. Test steam generation calculation with various board states\\n5. Test turn-based steam accumulation\\n6. Test edge cases like negative values and overflow\\n7. Mock InfluenceSystem for isolated testing",
-          "status": "done",
-          "dependencies": [
-            4
-          ],
-          "parentTaskId": 6
-        },
-        {
-          "id": 6,
-          "title": "Implement Steam UI Display for Local Player",
-          "description": "Add UI element to display the local player's current steam amount in the game interface",
-          "details": "1. Add sf::Text UI element for steam display\n2. Position steam display in the local player info area\n3. Update steam display in GameStart and GameStateUpdate handlers\n4. Ensure proper formatting and styling consistency\n5. Test steam display updates during gameplay",
-          "status": "done",
-          "dependencies": [
-            5
-          ],
-          "parentTaskId": 6
-        }
-      ]
-    },
-    {
-      "id": 7,
-      "title": "Implement Card System and Data Models",
-      "description": "Design and implement the card system with data models for different card types, costs, and effects.",
-      "details": "1. Create Card base class and derived card types\n2. Implement card attributes (cost, effects, piece creation)\n3. Design card data storage format\n4. Create card factory for generating cards\n5. Implement card collection management\n\nPseudo-code for card system:\n```cpp\nclass Card {\nprotected:\n    std::string name;\n    int steamCost;\n    std::string description;\n    \npublic:\n    Card(std::string name, int steamCost, std::string description);\n    virtual ~Card() = default;\n    \n    std::string getName() const;\n    int getSteamCost() const;\n    std::string getDescription() const;\n    \n    virtual bool canPlay(const GameState& gameState, PlayerSide player) const = 0;\n    virtual void play(GameState& gameState, PlayerSide player) = 0;\n};\n\nclass PieceCard : public Card {\nprivate:\n    PieceType pieceType;\n    \npublic:\n    PieceCard(std::string name, int steamCost, std::string description, PieceType pieceType);\n    \n    bool canPlay(const GameState& gameState, PlayerSide player) const override;\n    void play(GameState& gameState, PlayerSide player) override;\n};\n\nclass CardFactory {\npublic:\n    static std::unique_ptr<Card> createCard(CardType type);\n    static std::vector<std::unique_ptr<Card>> createStarterDeck();\n};\n```",
-      "testStrategy": "1. Unit tests for card creation and attributes\n2. Verify card play conditions\n3. Test card effects on game state\n4. Validate card collection management\n5. Ensure proper card type identification and serialization",
-      "priority": "high",
-      "dependencies": [
-        2
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Design Card Base Class and Type System",
-          "description": "Create the foundational Card base class with common attributes and define necessary enums for card types, piece types, and player sides.",
-          "details": "1. Create Card.h header file with base Card class\n2. Define CardType enum (PieceCard, EffectCard, SpellCard, etc.)\n3. Define PieceType enum for different pieces that can be created\n4. Implement basic card attributes (name, steamCost, description, cardType)\n5. Define pure virtual methods for canPlay() and play()\n6. Add proper C++20 features like concepts if applicable\n7. Include proper forward declarations and includes",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 7
-        },
-        {
-          "id": 2,
-          "title": "Implement PieceCard Class",
-          "description": "Create the PieceCard class for cards that spawn new pieces on the board.",
-          "details": "1. Create PieceCard.h and PieceCard.cpp files\n2. Inherit from Card base class\n3. Add pieceType attribute to specify which piece to create\n4. Implement canPlay() method to check for valid placement positions\n5. Implement play() method to create and place piece on board\n6. Add validation for steam cost and board state\n7. Include proper error handling for invalid placements",
-          "status": "done",
-          "dependencies": [
-            1
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 3,
-          "title": "Implement EffectCard Class",
-          "description": "Create the EffectCard class for cards that apply temporary or permanent effects to the game state.",
-          "details": "1. Create EffectCard.h and EffectCard.cpp files\n2. Inherit from Card base class\n3. Define EffectType enum (Heal, Damage, Buff, Debuff, etc.)\n4. Add effect attributes (effectType, magnitude, duration, target)\n5. Implement canPlay() method to validate effect targets\n6. Implement play() method to apply effects to pieces or board\n7. Add support for both instant and ongoing effects",
-          "status": "done",
-          "dependencies": [
-            1
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 4,
-          "title": "Create Card Factory System",
-          "description": "Implement a factory pattern for creating cards and managing card definitions.",
-          "details": "1. Create CardFactory.h and CardFactory.cpp files\n2. Implement static factory methods for creating different card types\n3. Create card definition data structure (JSON or hardcoded)\n4. Add methods for creating starter decks for each player\n5. Implement card ID system for unique identification\n6. Add validation for card creation parameters\n7. Include methods for loading card definitions from external files",
-          "status": "done",
-          "dependencies": [
-            2,
-            3
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 5,
-          "title": "Implement Card Data Storage and Serialization",
-          "description": "Create systems for storing card data and serializing/deserializing card collections.",
-          "details": "1. Design card data format (JSON structure)\n2. Implement card serialization methods (toJson, fromJson)\n3. Create card collection serialization for decks and hands\n4. Add file I/O operations for saving/loading card data\n5. Implement validation for loaded card data\n6. Add error handling for corrupted or invalid card files\n7. Create utility functions for card data manipulation",
-          "status": "done",
-          "dependencies": [
-            4
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 6,
-          "title": "Integrate Card System with Game Engine",
-          "description": "Connect the card system with existing game components like GameState, ResourceSystem, and Board.",
-          "details": "1. Add card system integration to GameState class\n2. Connect card play mechanics with ResourceSystem for steam costs\n3. Integrate card effects with existing piece and board systems\n4. Add card system to game initialization and reset procedures\n5. Implement proper cleanup and memory management for cards\n6. Add event system for card-related game events\n7. Ensure thread safety if applicable",
-          "status": "done",
-          "dependencies": [
-            5
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 7,
-          "title": "Create Card Validation and Play Mechanics",
-          "description": "Implement comprehensive validation and execution systems for card play.",
-          "details": "1. Create CardPlayValidator class for pre-play validation\n2. Implement target validation for different card types\n3. Add placement validation for piece cards\n4. Create effect validation for effect cards\n5. Implement card play execution pipeline\n6. Add rollback mechanisms for failed card plays\n7. Create comprehensive error reporting for invalid plays",
-          "status": "done",
-          "dependencies": [
-            6
-          ],
-          "parentTaskId": 7
-        },
-        {
-          "id": 8,
-          "title": "Implement Unit Tests for Card System",
-          "description": "Create comprehensive unit tests for all card system components.",
-          "details": "1. Create test files for each card class (Card, PieceCard, EffectCard)\n2. Test card creation and attribute access\n3. Test card play validation and execution\n4. Test card factory functionality\n5. Test card serialization and deserialization\n6. Test integration with game systems\n7. Add performance tests for card operations\n8. Create mock objects for isolated testing",
-          "status": "done",
-          "dependencies": [
-            7
-          ],
-          "parentTaskId": 7
-        }
-      ]
-    },
-    {
-      "id": 8,
-      "title": "Implement Hand and Deck Management",
-      "description": "Create the system for managing player hands (4 cards) and decks (20 cards with max 2 copies of each card).",
-      "details": "1. Implement deck class with shuffling and drawing\n2. Create hand management with 4-card limit\n3. Implement deck building constraints (20 cards, max 2 copies)\n4. Create card drawing and discarding mechanics\n5. Implement deck validation\n\nPseudo-code for deck and hand management:\n```cpp\nclass Deck {\nprivate:\n    std::vector<std::unique_ptr<Card>> cards;\n    \npublic:\n    Deck();\n    \n    void addCard(std::unique_ptr<Card> card);\n    std::unique_ptr<Card> drawCard();\n    void shuffle();\n    size_t size() const;\n    bool isEmpty() const;\n    bool isValid() const; // Checks 20 card limit and max 2 copies rule\n};\n\nclass Hand {\nprivate:\n    std::vector<std::unique_ptr<Card>> cards;\n    static const size_t MAX_HAND_SIZE = 4;\n    \npublic:\n    Hand();\n    \n    bool addCard(std::unique_ptr<Card> card);\n    std::unique_ptr<Card> playCard(size_t index);\n    size_t size() const;\n    bool isFull() const;\n    const Card* getCard(size_t index) const;\n};\n```",
-      "testStrategy": "1. Unit tests for deck shuffling and drawing\n2. Verify hand management constraints\n3. Test deck building rules\n4. Validate card play from hand\n5. Ensure proper deck validation",
-      "priority": "medium",
-      "dependencies": [
-        7
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Design Deck Class Structure",
-          "description": "Create the Deck class with card storage, shuffling, and drawing capabilities",
-          "details": "1. Create Deck.h header file with class definition\n2. Implement private member for storing cards (vector of unique_ptr<Card>)\n3. Add constructor and destructor\n4. Implement addCard() method for deck building\n5. Implement drawCard() method that removes and returns top card\n6. Implement shuffle() method using random number generation\n7. Add size(), isEmpty(), and isValid() utility methods\n8. Include proper validation for deck constraints (20 cards, max 2 copies)",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 8
-        },
-        {
-          "id": 2,
-          "title": "Design Hand Class Structure",
-          "description": "Create the Hand class with 4-card limit and card management",
-          "details": "1. Create Hand.h header file with class definition\n2. Implement private member for storing cards (vector of unique_ptr<Card>)\n3. Define MAX_HAND_SIZE constant as 4\n4. Add constructor and destructor\n5. Implement addCard() method with hand size validation\n6. Implement playCard() method that removes and returns card by index\n7. Add size(), isFull(), and getCard() utility methods\n8. Include proper bounds checking and error handling",
-          "status": "done",
-          "dependencies": [
-            1
-          ],
-          "parentTaskId": 8
-        },
-        {
-          "id": 3,
-          "title": "Implement Deck Class Methods",
-          "description": "Implement the Deck class methods in Deck.cpp",
-          "details": "1. Create Deck.cpp implementation file\n2. Implement constructor and destructor\n3. Implement addCard() with validation for deck building rules\n4. Implement drawCard() with proper card removal and return\n5. Implement shuffle() using std::random_shuffle or std::shuffle\n6. Implement size(), isEmpty() utility methods\n7. Implement isValid() method to check 20-card limit and max 2 copies rule\n8. Add proper error handling and edge case management",
-          "status": "done",
-          "dependencies": [
-            1,
-            2
-          ],
-          "parentTaskId": 8
-        },
-        {
-          "id": 4,
-          "title": "Implement Hand Class Methods",
-          "description": "Implement the Hand class methods in Hand.cpp",
-          "details": "1. Create Hand.cpp implementation file\n2. Implement constructor and destructor\n3. Implement addCard() with hand size limit validation\n4. Implement playCard() with bounds checking and card removal\n5. Implement size(), isFull() utility methods\n6. Implement getCard() with const correctness and bounds checking\n7. Add proper error handling for invalid operations\n8. Include logging or debug output for hand operations",
-          "status": "done",
-          "dependencies": [
-            2,
-            3
-          ],
-          "parentTaskId": 8
-        },
-        {
-          "id": 5,
-          "title": "Integrate with GameState",
-          "description": "Integrate Deck and Hand classes with the existing GameState system",
-          "details": "1. Add Deck and Hand includes to GameState.h\n2. Add player deck and hand members to GameState class\n3. Update GameState constructor to initialize decks and hands\n4. Add methods to access player decks and hands\n5. Integrate deck/hand operations with turn management\n6. Update game initialization to create starter decks\n7. Add deck/hand state to game serialization if applicable\n8. Ensure proper cleanup and memory management",
-          "status": "done",
-          "dependencies": [
-            3,
-            4
-          ],
-          "parentTaskId": 8
-        },
-        {
-          "id": 6,
-          "title": "Create Unit Tests",
-          "description": "Create comprehensive unit tests for Deck and Hand classes",
-          "details": "1. Create test_Deck.cpp for Deck class testing\n2. Create test_Hand.cpp for Hand class testing\n3. Test deck creation, shuffling, and drawing\n4. Test hand management with size limits\n5. Test deck validation rules (20 cards, max 2 copies)\n6. Test edge cases like empty decks/hands\n7. Test integration with card system\n8. Add performance tests for large deck operations",
-          "status": "done",
-          "dependencies": [
-            5
-          ],
-          "parentTaskId": 8
-        }
-      ]
-    },
-    {
-      "id": 9,
-      "title": "Implement Card Play Mechanics",
-      "description": "Create the system for playing cards from hand, spending steam resources, and adding new pieces to the board.",
-      "details": "1. Implement card selection and validation\n2. Create steam cost payment system\n3. Implement piece placement from cards\n4. Create valid placement detection\n5. Implement card effect resolution\n\nPseudo-code for card play system:\n```cpp\nclass CardPlaySystem {\npublic:\n    static bool canPlayCard(const GameState& gameState, PlayerSide player, size_t handIndex);\n    static bool playCard(GameState& gameState, PlayerSide player, size_t handIndex, Position targetPos);\n    static std::vector<Position> getValidPlacementPositions(const GameState& gameState, PlayerSide player, const Card* card);\n};\n\nbool CardPlaySystem::playCard(GameState& gameState, PlayerSide player, size_t handIndex, Position targetPos) {\n    if (!canPlayCard(gameState, player, handIndex)) {\n        return false;\n    }\n    \n    const Card* card = gameState.getPlayerHand(player).getCard(handIndex);\n    int steamCost = card->getSteamCost();\n    \n    // Check if player has enough steam\n    if (gameState.getResourceSystem().getSteam(player) < steamCost) {\n        return false;\n    }\n    \n    // Check if target position is valid for this card\n    auto validPositions = getValidPlacementPositions(gameState, player, card);\n    if (std::find(validPositions.begin(), validPositions.end(), targetPos) == validPositions.end()) {\n        return false;\n    }\n    \n    // Spend steam\n    gameState.getResourceSystem().spendSteam(player, steamCost);\n    \n    // Play the card\n    std::unique_ptr<Card> playedCard = gameState.getPlayerHand(player).playCard(handIndex);\n    playedCard->play(gameState, player);\n    \n    // Draw a new card if possible\n    if (!gameState.getPlayerDeck(player).isEmpty()) {\n        gameState.getPlayerHand(player).addCard(gameState.getPlayerDeck(player).drawCard());\n    }\n    \n    return true;\n}\n```",
-      "testStrategy": "1. Unit tests for card play validation\n2. Verify steam cost payment\n3. Test piece placement from cards\n4. Validate card effect resolution\n5. Ensure proper hand/deck updates after card play",
-      "priority": "high",
-      "dependencies": [
-        6,
-        8
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Implement TurnManager Card Play Processing",
-          "description": "Replace the placeholder processPlayCardAction method in TurnManager with actual card play logic using the existing CardPlayValidator",
-          "details": "1. Update TurnManager::processPlayCardAction() to use CardPlayValidator::executeCardPlay()\n2. Add proper error handling and result conversion\n3. Integrate with turn switching logic\n4. Add validation for player turn and game state",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 9
-        },
-        {
-          "id": 2,
-          "title": "Add Card UI Rendering",
-          "description": "Implement hand display in the main game loop showing the local player's cards with names, steam costs, and visual feedback",
-          "details": "1. Add card rendering function to main.cpp\n2. Display cards horizontally below the game board\n3. Show card name, steam cost, and type\n4. Add visual feedback for playable/unplayable cards based on steam\n5. Position cards appropriately using GraphicsManager scaling",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 9
-        },
-        {
-          "id": 3,
-          "title": "Extend InputManager for Card Interaction",
-          "description": "Add card click detection and card play interaction to InputManager, implementing the click-card-then-click-target workflow",
-          "details": "1. Add card area click detection to InputManager\n2. Implement card selection state management\n3. Add target selection for card play\n4. Integrate with existing mouse handling system\n5. Add visual feedback for selected cards and valid targets",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 9
-        },
-        {
-          "id": 4,
-          "title": "Add Network Protocol for Card Play",
-          "description": "Extend the network protocol to support card play messages for multiplayer synchronization",
-          "details": "1. Add CardPlayToServer message type to NetworkProtocol.h\n2. Implement sf::Packet operators for card play data\n3. Add server-side card play message handling\n4. Add client-side card play result handling\n5. Ensure proper game state synchronization",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 9
-        }
-      ]
-    },
-    {
-      "id": 10,
-      "title": "Implement Game State Management and Turn System",
-      "description": "Create the system for managing game state, turn progression, and win conditions.",
-      "details": "1. Implement game state class with all game components\n2. Create turn system with phases (draw, play, move)\n3. Implement win condition detection (king death)\n4. Create game initialization and reset\n5. Implement game state serialization for save/load\n\nPseudo-code for game state management:\n```cpp\nclass GameState {\nprivate:\n    GameBoard board;\n    ResourceSystem resourceSystem;\n    std::array<Hand, 2> playerHands;\n    std::array<Deck, 2> playerDecks;\n    PlayerSide currentPlayer;\n    GamePhase currentPhase;\n    bool gameOver;\n    PlayerSide winner;\n    \npublic:\n    GameState();\n    \n    void initializeGame();\n    void startTurn();\n    void endTurn();\n    void nextPhase();\n    \n    bool isGameOver() const;\n    PlayerSide getWinner() const;\n    void checkWinConditions();\n    \n    GameBoard& getBoard();\n    ResourceSystem& getResourceSystem();\n    Hand& getPlayerHand(PlayerSide player);\n    Deck& getPlayerDeck(PlayerSide player);\n    PlayerSide getCurrentPlayer() const;\n    GamePhase getCurrentPhase() const;\n};\n\nvoid GameState::checkWinConditions() {\n    bool player1KingAlive = false;\n    bool player2KingAlive = false;\n    \n    // Check if kings are alive\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            if (!square.isEmpty()) {\n                Piece* piece = square.getPiece();\n                if (dynamic_cast<King*>(piece)) {\n                    if (piece->getOwner() == PlayerSide::PLAYER_1) {\n                        player1KingAlive = true;\n                    } else {\n                        player2KingAlive = true;\n                    }\n                }\n            }\n        }\n    }\n    \n    if (!player1KingAlive) {\n        gameOver = true;\n        winner = PlayerSide::PLAYER_2;\n    } else if (!player2KingAlive) {\n        gameOver = true;\n        winner = PlayerSide::PLAYER_1;\n    }\n}\n```",
-      "testStrategy": "1. Unit tests for turn progression\n2. Verify win condition detection\n3. Test game initialization\n4. Validate phase transitions\n5. Ensure proper game state serialization",
-      "priority": "high",
-      "dependencies": [
-        4,
-        6,
-        9
-      ],
-      "status": "done",
-      "subtasks": [
-        {
-          "id": 1,
-          "title": "Verify Game State Integration",
-          "description": "Test and verify that all game state components work together correctly",
-          "details": "1. Test GameState initialization and reset functionality\\n2. Verify turn progression and player switching\\n3. Test steam generation and resource management\\n4. Verify card system integration\\n5. Test win condition detection\\n6. Ensure proper game state serialization",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 10
-        },
-        {
-          "id": 2,
-          "title": "Implement Game Phase System",
-          "description": "Add proper game phase transitions (draw, play, move phases) to the turn system",
-          "details": "1. Define GamePhase enum with DRAW, PLAY, MOVE phases\\n2. Update TurnManager to handle phase transitions\\n3. Implement phase-specific action validation\\n4. Add phase progression logic within turns\\n5. Update UI to display current phase\\n6. Test phase transitions and restrictions",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 10
-        },
-        {
-          "id": 3,
-          "title": "Enhance Win Condition System",
-          "description": "Improve and test the win condition detection system",
-          "details": "1. Test king death detection in GameRules\\n2. Verify proper game result setting\\n3. Add additional win conditions if needed\\n4. Test game over state transitions\\n5. Ensure proper cleanup when game ends\\n6. Add win condition notifications",
-          "status": "done",
-          "dependencies": [],
-          "parentTaskId": 10
-        }
-      ]
-    },
-    {
-      "id": 11,
-      "title": "Implement Game Board Visualization with SFML",
-      "description": "Create the visual representation of the game board, pieces, and control indicators using SFML.",
-      "details": "1. Create board grid visualization\n2. Implement piece sprites and rendering\n3. Create visual indicators for square control\n4. Implement highlighting for valid moves\n5. Create animations for piece movement and combat\n\nPseudo-code for board visualization:\n```cpp\nclass BoardView {\nprivate:\n    sf::RenderWindow& window;\n    sf::Texture boardTexture;\n    sf::Sprite boardSprite;\n    std::map<PieceType, sf::Texture> pieceTextures;\n    std::vector<sf::Sprite> pieceSprites;\n    \n    float squareSize;\n    sf::Vector2f boardPosition;\n    \npublic:\n    BoardView(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateView(const GameBoard& board);\n    void drawBoard();\n    void drawPieces(const GameBoard& board);\n    void drawControlIndicators(const GameBoard& board);\n    void drawValidMoves(const std::vector<Position>& validMoves);\n    \n    Position screenToBoard(sf::Vector2f screenPos) const;\n    sf::Vector2f boardToScreen(Position boardPos) const;\n};\n\nvoid BoardView::drawControlIndicators(const GameBoard& board) {\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            PlayerSide controller = InfluenceSystem::getControllingPlayer(square);\n            \n            if (controller != PlayerSide::NONE) {\n                sf::RectangleShape indicator(sf::Vector2f(squareSize, squareSize));\n                indicator.setPosition(boardToScreen(Position{x, y}));\n                \n                if (controller == PlayerSide::PLAYER_1) {\n                    indicator.setFillColor(sf::Color(0, 0, 255, 64)); // Blue with transparency\n                } else {\n                    indicator.setFillColor(sf::Color(255, 0, 0, 64)); // Red with transparency\n                }\n                \n                window.draw(indicator);\n            }\n        }\n    }\n}\n```",
-      "testStrategy": "1. Visual verification of board rendering\n2. Test piece sprite rendering\n3. Verify control indicators\n4. Test move highlighting\n5. Validate animations and transitions",
-      "priority": "medium",
-      "dependencies": [
-        1,
-        2,
-        5
-      ],
-      "status": "pending",
-      "subtasks": []
-    },
-    {
-      "id": 12,
-      "title": "Implement User Interface for Game State and Resources",
-      "description": "Create the UI elements for displaying game state, player resources, and turn information.",
-      "details": "1. Implement steam resource display\n2. Create turn and phase indicators\n3. Implement player information display\n4. Create game state notifications\n5. Implement UI layout and styling\n\nPseudo-code for UI implementation:\n```cpp\nclass GameUI {\nprivate:\n    sf::RenderWindow& window;\n    sf::Font font;\n    \n    sf::Text player1Info;\n    sf::Text player2Info;\n    sf::Text phaseInfo;\n    sf::Text steamInfo;\n    sf::Text notificationText;\n    \npublic:\n    GameUI(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateUI(const GameState& gameState);\n    void drawUI();\n    \n    void showNotification(const std::string& message, float duration = 3.0f);\n};\n\nvoid GameUI::updateUI(const GameState& gameState) {\n    // Update player info\n    player1Info.setString(\"Player 1\");\n    player2Info.setString(\"Player 2\");\n    \n    // Update phase info\n    std::string phaseStr;\n    switch (gameState.getCurrentPhase()) {\n        case GamePhase::DRAW: phaseStr = \"Draw Phase\"; break;\n        case GamePhase::PLAY: phaseStr = \"Play Phase\"; break;\n        case GamePhase::MOVE: phaseStr = \"Move Phase\"; break;\n    }\n    phaseInfo.setString(phaseStr);\n    \n    // Update steam info\n    int player1Steam = gameState.getResourceSystem().getSteam(PlayerSide::PLAYER_1);\n    int player2Steam = gameState.getResourceSystem().getSteam(PlayerSide::PLAYER_2);\n    steamInfo.setString(\"Steam - P1: \" + std::to_string(player1Steam) + \n                        \" | P2: \" + std::to_string(player2Steam));\n    \n    // Highlight current player\n    if (gameState.getCurrentPlayer() == PlayerSide::PLAYER_1) {\n        player1Info.setFillColor(sf::Color::Yellow);\n        player2Info.setFillColor(sf::Color::White);\n    } else {\n        player1Info.setFillColor(sf::Color::White);\n        player2Info.setFillColor(sf::Color::Yellow);\n    }\n}\n```",
-      "testStrategy": "1. Visual verification of UI elements\n2. Test resource display accuracy\n3. Verify turn and phase indicators\n4. Test notification system\n5. Validate UI updates on game state changes",
-      "priority": "medium",
-      "dependencies": [
-        6,
-        10,
-        11
-      ],
-      "status": "pending",
-      "subtasks": []
-    },
-    {
-      "id": 13,
-      "title": "Implement Hand and Card Visualization",
-      "description": "Create the visual representation of player hands and cards with interactive elements.",
-      "details": "1. Implement card visual design\n2. Create hand layout and positioning\n3. Implement card selection and highlighting\n4. Create card detail view\n5. Implement drag-and-drop for card play\n\nPseudo-code for hand visualization:\n```cpp\nclass HandView {\nprivate:\n    sf::RenderWindow& window;\n    sf::Font font;\n    std::vector<sf::RectangleShape> cardShapes;\n    std::vector<sf::Text> cardTexts;\n    \n    sf::Vector2f handPosition;\n    float cardWidth;\n    float cardHeight;\n    float cardSpacing;\n    \n    size_t selectedCardIndex;\n    bool isDragging;\n    sf::Vector2f dragOffset;\n    \npublic:\n    HandView(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateView(const Hand& hand);\n    void drawHand();\n    \n    size_t getCardIndexAtPosition(sf::Vector2f position) const;\n    bool handleMouseDown(sf::Vector2f position);\n    bool handleMouseMove(sf::Vector2f position);\n    bool handleMouseUp(sf::Vector2f position, GameState& gameState);\n};\n\nvoid HandView::updateView(const Hand& hand) {\n    cardShapes.clear();\n    cardTexts.clear();\n    \n    for (size_t i = 0; i < hand.size(); i++) {\n        const Card* card = hand.getCard(i);\n        \n        sf::RectangleShape cardShape(sf::Vector2f(cardWidth, cardHeight));\n        cardShape.setPosition(handPosition.x + i * (cardWidth + cardSpacing), handPosition.y);\n        cardShape.setFillColor(sf::Color::White);\n        cardShape.setOutlineThickness(2.0f);\n        cardShape.setOutlineColor(i == selectedCardIndex ? sf::Color::Yellow : sf::Color::Black);\n        \n        sf::Text nameText(card->getName(), font, 12);\n        nameText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 5));\n        \n        sf::Text costText(\"Cost: \" + std::to_string(card->getSteamCost()), font, 10);\n        costText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 25));\n        \n        sf::Text descText(card->getDescription(), font, 8);\n        descText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 45));\n        \n        cardShapes.push_back(cardShape);\n        cardTexts.push_back(nameText);\n        cardTexts.push_back(costText);\n        cardTexts.push_back(descText);\n    }\n}\n```",
-      "testStrategy": "1. Visual verification of card rendering\n2. Test card selection and highlighting\n3. Verify drag-and-drop functionality\n4. Test card detail view\n5. Validate hand updates when cards are played or drawn",
-      "priority": "medium",
-      "dependencies": [
-        8,
-        11
-      ],
-      "status": "pending",
-      "subtasks": []
-    },
-    {
-      "id": 14,
-      "title": "Implement Input Handling and Game Controls",
-      "description": "Create the input handling system for player interactions with the game board, pieces, and cards.",
-      "details": "1. Implement mouse input handling\n2. Create piece selection and movement\n3. Implement card selection and play\n4. Create turn and phase control buttons\n5. Implement keyboard shortcuts\n\nPseudo-code for input handling:\n```cpp\nclass InputHandler {\nprivate:\n    sf::RenderWindow& window;\n    GameState& gameState;\n    BoardView& boardView;\n    HandView& handView;\n    \n    bool pieceSelected;\n    Position selectedPiecePos;\n    std::vector<Position> validMoves;\n    \npublic:\n    InputHandler(sf::RenderWindow& window, GameState& gameState, BoardView& boardView, HandView& handView);\n    \n    void handleEvents();\n    void handleMouseClick(sf::Vector2f mousePos);\n    void handlePieceSelection(Position boardPos);\n    void handlePieceMovement(Position boardPos);\n    void handleCardPlay(size_t cardIndex, Position boardPos);\n    void handleEndTurnButton();\n};\n\nvoid InputHandler::handleMouseClick(sf::Vector2f mousePos) {\n    // Check if clicked on the board\n    Position boardPos = boardView.screenToBoard(mousePos);\n    if (boardPos.x >= 0 && boardPos.x < 8 && boardPos.y >= 0 && boardPos.y < 8) {\n        if (pieceSelected) {\n            handlePieceMovement(boardPos);\n        } else {\n            handlePieceSelection(boardPos);\n        }\n        return;\n    }\n    \n    // Check if clicked on a card in hand\n    size_t cardIndex = handView.getCardIndexAtPosition(mousePos);\n    if (cardIndex < gameState.getPlayerHand(gameState.getCurrentPlayer()).size()) {\n        // Start card drag operation\n        handView.handleMouseDown(mousePos);\n        return;\n    }\n    \n    // Check if clicked on end turn button\n    // ...\n}\n```",
-      "testStrategy": "1. Test mouse input handling\n2. Verify piece selection and movement\n3. Test card selection and play\n4. Validate turn and phase controls\n5. Ensure proper input validation and error handling",
-      "priority": "high",
-      "dependencies": [
-        11,
-        12,
-        13
-      ],
-      "status": "pending",
-      "subtasks": []
-    },
-    {
-      "id": 15,
-      "title": "Implement Simple AI Opponent",
-      "description": "Create a basic AI opponent for single-player testing with decision-making for piece movement and card play.",
-      "details": "1. Implement AI decision-making framework\n2. Create simple evaluation function for board state\n3. Implement basic move selection algorithm\n4. Create card play decision logic\n5. Implement difficulty levels\n\nPseudo-code for AI implementation:\n```cpp\nclass AIPlayer {\nprivate:\n    GameState& gameState;\n    PlayerSide side;\n    int difficultyLevel;\n    \n    struct Move {\n        Position from;\n        Position to;\n        float score;\n    };\n    \n    struct CardPlay {\n        size_t cardIndex;\n        Position targetPos;\n        float score;\n    };\n    \npublic:\n    AIPlayer(GameState& gameState, PlayerSide side, int difficultyLevel = 1);\n    \n    void takeTurn();\n    \nprivate:\n    float evaluateBoard();\n    std::vector<Move> generatePossibleMoves();\n    std::vector<CardPlay> generatePossibleCardPlays();\n    Move selectBestMove();\n    CardPlay selectBestCardPlay();\n};\n\nvoid AIPlayer::takeTurn() {\n    // Draw phase happens automatically\n    \n    // Play phase - try to play a card if possible\n    CardPlay bestCardPlay = selectBestCardPlay();\n    if (bestCardPlay.score > 0) {\n        const Card* card = gameState.getPlayerHand(side).getCard(bestCardPlay.cardIndex);\n        if (gameState.getResourceSystem().getSteam(side) >= card->getSteamCost()) {\n            CardPlaySystem::playCard(gameState, side, bestCardPlay.cardIndex, bestCardPlay.targetPos);\n        }\n    }\n    \n    // Move phase - move a piece\n    Move bestMove = selectBestMove();\n    if (bestMove.score > 0) {\n        Piece* piece = gameState.getBoard().getSquare(bestMove.from.x, bestMove.from.y).getPiece();\n        piece->executeMove(gameState.getBoard(), bestMove.from, bestMove.to);\n    }\n    \n    // End turn\n    gameState.endTurn();\n}\n```",
-      "testStrategy": "1. Test AI decision-making\n2. Verify move selection logic\n3. Test card play decisions\n4. Validate different difficulty levels\n5. Benchmark AI performance and response time",
-      "priority": "low",
-      "dependencies": [
-        10
-      ],
-      "status": "pending",
-      "subtasks": []
+            "status": "done"
+          },
+          {
+            "id": 4,
+            "title": "Integrate with game board",
+            "description": "Connect piece movement system with the game board representation",
+            "dependencies": [
+              2,
+              3
+            ],
+            "details": "Create methods to: update the board when pieces move, handle piece capture, validate moves against the current board state, and check for special conditions like check and checkmate. Implement a system to query the board for piece positions to use in movement validation. Ensure pieces can access board state to determine valid moves.",
+            "status": "done"
+          },
+          {
+            "id": 5,
+            "title": "Implement move execution and validation system",
+            "description": "Create a system to execute moves and validate their legality",
+            "dependencies": [
+              3,
+              4
+            ],
+            "details": "Develop a move execution system that: validates moves before execution, handles the actual movement of pieces on the board, manages piece capture, implements special moves (castling, en passant, promotion), and ensures a player cannot make moves that leave their king in check. Include a method to generate all legal moves for a given player.",
+            "status": "done"
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Implement Combat System",
+        "description": "Create the combat system for pieces to attack and damage each other, including health tracking and piece removal.",
+        "details": "1. Implement attack mechanics between pieces\n2. Create damage calculation system\n3. Implement health tracking and piece death\n4. Handle piece removal from board\n5. Implement combat resolution logic\n\nPseudo-code for combat system:\n```cpp\nclass CombatSystem {\npublic:\n    static void resolveCombat(GameBoard& board, Position attacker, Position defender);\n    static void applyDamage(Piece* attacker, Piece* defender);\n    static void checkAndRemoveDeadPieces(GameBoard& board);\n};\n\nvoid CombatSystem::resolveCombat(GameBoard& board, Position attacker, Position defender) {\n    Piece* attackingPiece = board.getSquare(attacker.x, attacker.y).getPiece();\n    Piece* defendingPiece = board.getSquare(defender.x, defender.y).getPiece();\n    \n    if (attackingPiece && defendingPiece && \n        attackingPiece->getOwner() != defendingPiece->getOwner()) {\n        applyDamage(attackingPiece, defendingPiece);\n        checkAndRemoveDeadPieces(board);\n    }\n}\n```",
+        "testStrategy": "1. Unit tests for damage calculation\n2. Verify piece death and removal\n3. Test various combat scenarios\n4. Validate king death detection\n5. Ensure proper combat resolution order",
+        "priority": "high",
+        "dependencies": [
+          3
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Design combat data structures",
+            "description": "Create the necessary data structures to track combat-related information such as piece health, attack values, and combat status.",
+            "dependencies": [],
+            "details": "Define classes or interfaces for combat attributes (health, attack power, defense). Implement health tracking for each piece on the board. Create a system to track combat history for potential undo/replay features. Ensure these structures integrate with the existing piece representation.",
+            "status": "done"
+          },
+          {
+            "id": 2,
+            "title": "Implement damage calculation logic",
+            "description": "Create the core algorithm for calculating damage during combat encounters between pieces.",
+            "dependencies": [
+              1
+            ],
+            "details": "Develop formulas for attack and defense calculations. Implement modifiers based on piece types or special abilities. Create random elements if needed (critical hits, miss chance). Include logic for environmental or positional bonuses/penalties. Add methods to apply calculated damage to pieces.",
+            "status": "done"
+          },
+          {
+            "id": 3,
+            "title": "Develop health tracking system",
+            "description": "Build a system to monitor and update the health status of pieces during and after combat.",
+            "dependencies": [
+              1,
+              2
+            ],
+            "details": "Implement methods to reduce health based on damage taken. Create visual indicators for current health status. Add logic to detect when health reaches zero or critical levels. Implement any healing or regeneration mechanics if applicable. Ensure health changes trigger appropriate UI updates.",
+            "status": "done"
+          },
+          {
+            "id": 4,
+            "title": "Create piece removal logic",
+            "description": "Implement the system for removing pieces from the board when they are defeated in combat.",
+            "dependencies": [
+              3
+            ],
+            "details": "Develop logic to detect when a piece should be removed (health <= 0). Create methods to safely remove pieces from the game board. Implement any death effects or consequences. Handle cleanup of references to removed pieces. Add animations or visual feedback for piece removal.",
+            "status": "done"
+          },
+          {
+            "id": 5,
+            "title": "Integrate combat system with game board state",
+            "description": "Connect the combat system with the overall game state to ensure proper interaction with other game systems.",
+            "dependencies": [
+              2,
+              3,
+              4
+            ],
+            "details": "Implement combat initiation based on game rules (adjacent pieces, attack commands). Create event system for combat-related events (attack, damage, defeat). Update game state after combat resolution. Ensure combat results affect turn progression appropriately. Add combat logs or history tracking for player information.",
+            "status": "done"
+          }
+        ]
+      },
+      {
+        "id": 5,
+        "title": "Implement Influence and Control System",
+        "description": "Create the system for calculating piece influence on adjacent squares and determining square control.",
+        "details": "1. Implement influence calculation for each piece type\n2. Create system to propagate influence to adjacent squares\n3. Implement control determination based on influence values\n4. Update control values when pieces move or are removed\n5. Optimize influence calculation for performance\n\nPseudo-code for influence system:\n```cpp\nclass InfluenceSystem {\npublic:\n    static void calculateBoardInfluence(GameBoard& board);\n    static void calculatePieceInfluence(GameBoard& board, Position piecePos);\n    static void determineSquareControl(GameBoard& board);\n    static PlayerSide getControllingPlayer(const Square& square);\n};\n\nvoid InfluenceSystem::calculateBoardInfluence(GameBoard& board) {\n    // Reset all influence values\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            board.getSquare(x, y).setControlValue(PlayerSide::PLAYER_1, 0);\n            board.getSquare(x, y).setControlValue(PlayerSide::PLAYER_2, 0);\n        }\n    }\n    \n    // Calculate influence for each piece\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            if (!board.getSquare(x, y).isEmpty()) {\n                calculatePieceInfluence(board, Position{x, y});\n            }\n        }\n    }\n    \n    determineSquareControl(board);\n}\n```",
+        "testStrategy": "1. Unit tests for influence calculation\n2. Verify control determination logic\n3. Test influence propagation\n4. Benchmark performance for large board states\n5. Validate control changes after piece movement",
+        "priority": "high",
+        "dependencies": [
+          3
+        ],
+        "status": "done",
+        "subtasks": []
+      },
+      {
+        "id": 6,
+        "title": "Implement Steam Resource Generation System",
+        "description": "Create the system for generating and managing the 'Steam' resource based on controlled squares.",
+        "details": "1. Implement steam resource tracking for each player\n2. Create system to calculate steam generation based on controlled squares\n3. Implement steam accumulation per turn\n4. Create methods for spending steam\n5. Implement UI indicators for steam resources\n\nPseudo-code for steam resource system:\n```cpp\nclass ResourceSystem {\nprivate:\n    int player1Steam;\n    int player2Steam;\n    \npublic:\n    ResourceSystem();\n    \n    int getSteam(PlayerSide player) const;\n    void setSteam(PlayerSide player, int amount);\n    void addSteam(PlayerSide player, int amount);\n    bool spendSteam(PlayerSide player, int amount);\n    \n    void calculateSteamGeneration(const GameBoard& board);\n    void processTurnStart(PlayerSide activePlayer, const GameBoard& board);\n};\n\nvoid ResourceSystem::calculateSteamGeneration(const GameBoard& board) {\n    int player1Generation = 0;\n    int player2Generation = 0;\n    \n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            PlayerSide controller = InfluenceSystem::getControllingPlayer(square);\n            \n            if (controller == PlayerSide::PLAYER_1) {\n                player1Generation++;\n            } else if (controller == PlayerSide::PLAYER_2) {\n                player2Generation++;\n            }\n        }\n    }\n    \n    // Store generation values for use in processTurnStart\n}\n```",
+        "testStrategy": "1. Unit tests for steam calculation\n2. Verify steam accumulation per turn\n3. Test steam spending mechanics\n4. Validate resource updates based on board control changes\n5. Ensure proper resource limits and constraints",
+        "priority": "medium",
+        "dependencies": [
+          5
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Create ResourceSystem Class Structure",
+            "description": "Design and implement the basic ResourceSystem class with steam tracking for both players",
+            "details": "1. Create ResourceSystem.h header file\\n2. Define private member variables for player1Steam and player2Steam\\n3. Implement constructor to initialize steam values\\n4. Add getter methods: getSteam(PlayerSide player)\\n5. Add setter methods: setSteam(PlayerSide player, int amount)\\n6. Add utility methods: addSteam() and spendSteam()\\n7. Include proper error checking for negative values",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 6
+          },
+          {
+            "id": 2,
+            "title": "Implement Steam Generation Calculation",
+            "description": "Create the logic to calculate steam generation based on controlled squares using the InfluenceSystem",
+            "details": "1. Implement calculateSteamGeneration(const GameBoard& board) method\\n2. Iterate through all board squares (8x8 grid)\\n3. Use InfluenceSystem::getControllingPlayer() to determine square control\\n4. Count controlled squares for each player\\n5. Store generation values for use in turn processing\\n6. Add configurable steam generation rates if needed",
+            "status": "done",
+            "dependencies": [
+              1
+            ],
+            "parentTaskId": 6
+          },
+          {
+            "id": 3,
+            "title": "Implement Turn-Based Steam Processing",
+            "description": "Create the processTurnStart method to add generated steam to players at the beginning of their turn",
+            "details": "1. Implement processTurnStart(PlayerSide activePlayer, const GameBoard& board) method\\n2. Call calculateSteamGeneration() to get current generation values\\n3. Add generated steam to the active player's total\\n4. Ensure steam accumulation is properly tracked\\n5. Add logging/debugging output for steam generation\\n6. Handle edge cases like maximum steam limits if applicable",
+            "status": "done",
+            "dependencies": [
+              2
+            ],
+            "parentTaskId": 6
+          },
+          {
+            "id": 4,
+            "title": "Integrate ResourceSystem with Game Engine",
+            "description": "Connect the ResourceSystem with the existing game engine components and ensure proper integration",
+            "details": "1. Add ResourceSystem as a member to GameState or GameBoard class\\n2. Update existing game loop to call processTurnStart() at turn beginning\\n3. Ensure ResourceSystem is properly initialized in game setup\\n4. Add methods to query steam values from other game systems\\n5. Update any existing placeholder resource code\\n6. Test integration with existing piece and board systems",
+            "status": "done",
+            "dependencies": [
+              3
+            ],
+            "parentTaskId": 6
+          },
+          {
+            "id": 5,
+            "title": "Create Unit Tests for ResourceSystem",
+            "description": "Implement comprehensive unit tests to verify steam calculation, accumulation, and spending mechanics",
+            "details": "1. Create test file for ResourceSystem (test_ResourceSystem.cpp)\\n2. Test basic steam getter/setter functionality\\n3. Test steam spending with sufficient and insufficient funds\\n4. Test steam generation calculation with various board states\\n5. Test turn-based steam accumulation\\n6. Test edge cases like negative values and overflow\\n7. Mock InfluenceSystem for isolated testing",
+            "status": "done",
+            "dependencies": [
+              4
+            ],
+            "parentTaskId": 6
+          },
+          {
+            "id": 6,
+            "title": "Implement Steam UI Display for Local Player",
+            "description": "Add UI element to display the local player's current steam amount in the game interface",
+            "details": "1. Add sf::Text UI element for steam display\n2. Position steam display in the local player info area\n3. Update steam display in GameStart and GameStateUpdate handlers\n4. Ensure proper formatting and styling consistency\n5. Test steam display updates during gameplay",
+            "status": "done",
+            "dependencies": [
+              5
+            ],
+            "parentTaskId": 6
+          }
+        ]
+      },
+      {
+        "id": 7,
+        "title": "Implement Card System and Data Models",
+        "description": "Design and implement the card system with data models for different card types, costs, and effects.",
+        "details": "1. Create Card base class and derived card types\n2. Implement card attributes (cost, effects, piece creation)\n3. Design card data storage format\n4. Create card factory for generating cards\n5. Implement card collection management\n\nPseudo-code for card system:\n```cpp\nclass Card {\nprotected:\n    std::string name;\n    int steamCost;\n    std::string description;\n    \npublic:\n    Card(std::string name, int steamCost, std::string description);\n    virtual ~Card() = default;\n    \n    std::string getName() const;\n    int getSteamCost() const;\n    std::string getDescription() const;\n    \n    virtual bool canPlay(const GameState& gameState, PlayerSide player) const = 0;\n    virtual void play(GameState& gameState, PlayerSide player) = 0;\n};\n\nclass PieceCard : public Card {\nprivate:\n    PieceType pieceType;\n    \npublic:\n    PieceCard(std::string name, int steamCost, std::string description, PieceType pieceType);\n    \n    bool canPlay(const GameState& gameState, PlayerSide player) const override;\n    void play(GameState& gameState, PlayerSide player) override;\n};\n\nclass CardFactory {\npublic:\n    static std::unique_ptr<Card> createCard(CardType type);\n    static std::vector<std::unique_ptr<Card>> createStarterDeck();\n};\n```",
+        "testStrategy": "1. Unit tests for card creation and attributes\n2. Verify card play conditions\n3. Test card effects on game state\n4. Validate card collection management\n5. Ensure proper card type identification and serialization",
+        "priority": "high",
+        "dependencies": [
+          2
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Design Card Base Class and Type System",
+            "description": "Create the foundational Card base class with common attributes and define necessary enums for card types, piece types, and player sides.",
+            "details": "1. Create Card.h header file with base Card class\n2. Define CardType enum (PieceCard, EffectCard, SpellCard, etc.)\n3. Define PieceType enum for different pieces that can be created\n4. Implement basic card attributes (name, steamCost, description, cardType)\n5. Define pure virtual methods for canPlay() and play()\n6. Add proper C++20 features like concepts if applicable\n7. Include proper forward declarations and includes",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 7
+          },
+          {
+            "id": 2,
+            "title": "Implement PieceCard Class",
+            "description": "Create the PieceCard class for cards that spawn new pieces on the board.",
+            "details": "1. Create PieceCard.h and PieceCard.cpp files\n2. Inherit from Card base class\n3. Add pieceType attribute to specify which piece to create\n4. Implement canPlay() method to check for valid placement positions\n5. Implement play() method to create and place piece on board\n6. Add validation for steam cost and board state\n7. Include proper error handling for invalid placements",
+            "status": "done",
+            "dependencies": [
+              1
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 3,
+            "title": "Implement EffectCard Class",
+            "description": "Create the EffectCard class for cards that apply temporary or permanent effects to the game state.",
+            "details": "1. Create EffectCard.h and EffectCard.cpp files\n2. Inherit from Card base class\n3. Define EffectType enum (Heal, Damage, Buff, Debuff, etc.)\n4. Add effect attributes (effectType, magnitude, duration, target)\n5. Implement canPlay() method to validate effect targets\n6. Implement play() method to apply effects to pieces or board\n7. Add support for both instant and ongoing effects",
+            "status": "done",
+            "dependencies": [
+              1
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 4,
+            "title": "Create Card Factory System",
+            "description": "Implement a factory pattern for creating cards and managing card definitions.",
+            "details": "1. Create CardFactory.h and CardFactory.cpp files\n2. Implement static factory methods for creating different card types\n3. Create card definition data structure (JSON or hardcoded)\n4. Add methods for creating starter decks for each player\n5. Implement card ID system for unique identification\n6. Add validation for card creation parameters\n7. Include methods for loading card definitions from external files",
+            "status": "done",
+            "dependencies": [
+              2,
+              3
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 5,
+            "title": "Implement Card Data Storage and Serialization",
+            "description": "Create systems for storing card data and serializing/deserializing card collections.",
+            "details": "1. Design card data format (JSON structure)\n2. Implement card serialization methods (toJson, fromJson)\n3. Create card collection serialization for decks and hands\n4. Add file I/O operations for saving/loading card data\n5. Implement validation for loaded card data\n6. Add error handling for corrupted or invalid card files\n7. Create utility functions for card data manipulation",
+            "status": "done",
+            "dependencies": [
+              4
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 6,
+            "title": "Integrate Card System with Game Engine",
+            "description": "Connect the card system with existing game components like GameState, ResourceSystem, and Board.",
+            "details": "1. Add card system integration to GameState class\n2. Connect card play mechanics with ResourceSystem for steam costs\n3. Integrate card effects with existing piece and board systems\n4. Add card system to game initialization and reset procedures\n5. Implement proper cleanup and memory management for cards\n6. Add event system for card-related game events\n7. Ensure thread safety if applicable",
+            "status": "done",
+            "dependencies": [
+              5
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 7,
+            "title": "Create Card Validation and Play Mechanics",
+            "description": "Implement comprehensive validation and execution systems for card play.",
+            "details": "1. Create CardPlayValidator class for pre-play validation\n2. Implement target validation for different card types\n3. Add placement validation for piece cards\n4. Create effect validation for effect cards\n5. Implement card play execution pipeline\n6. Add rollback mechanisms for failed card plays\n7. Create comprehensive error reporting for invalid plays",
+            "status": "done",
+            "dependencies": [
+              6
+            ],
+            "parentTaskId": 7
+          },
+          {
+            "id": 8,
+            "title": "Implement Unit Tests for Card System",
+            "description": "Create comprehensive unit tests for all card system components.",
+            "details": "1. Create test files for each card class (Card, PieceCard, EffectCard)\n2. Test card creation and attribute access\n3. Test card play validation and execution\n4. Test card factory functionality\n5. Test card serialization and deserialization\n6. Test integration with game systems\n7. Add performance tests for card operations\n8. Create mock objects for isolated testing",
+            "status": "done",
+            "dependencies": [
+              7
+            ],
+            "parentTaskId": 7
+          }
+        ]
+      },
+      {
+        "id": 8,
+        "title": "Implement Hand and Deck Management",
+        "description": "Create the system for managing player hands (4 cards) and decks (20 cards with max 2 copies of each card).",
+        "details": "1. Implement deck class with shuffling and drawing\n2. Create hand management with 4-card limit\n3. Implement deck building constraints (20 cards, max 2 copies)\n4. Create card drawing and discarding mechanics\n5. Implement deck validation\n\nPseudo-code for deck and hand management:\n```cpp\nclass Deck {\nprivate:\n    std::vector<std::unique_ptr<Card>> cards;\n    \npublic:\n    Deck();\n    \n    void addCard(std::unique_ptr<Card> card);\n    std::unique_ptr<Card> drawCard();\n    void shuffle();\n    size_t size() const;\n    bool isEmpty() const;\n    bool isValid() const; // Checks 20 card limit and max 2 copies rule\n};\n\nclass Hand {\nprivate:\n    std::vector<std::unique_ptr<Card>> cards;\n    static const size_t MAX_HAND_SIZE = 4;\n    \npublic:\n    Hand();\n    \n    bool addCard(std::unique_ptr<Card> card);\n    std::unique_ptr<Card> playCard(size_t index);\n    size_t size() const;\n    bool isFull() const;\n    const Card* getCard(size_t index) const;\n};\n```",
+        "testStrategy": "1. Unit tests for deck shuffling and drawing\n2. Verify hand management constraints\n3. Test deck building rules\n4. Validate card play from hand\n5. Ensure proper deck validation",
+        "priority": "medium",
+        "dependencies": [
+          7
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Design Deck Class Structure",
+            "description": "Create the Deck class with card storage, shuffling, and drawing capabilities",
+            "details": "1. Create Deck.h header file with class definition\n2. Implement private member for storing cards (vector of unique_ptr<Card>)\n3. Add constructor and destructor\n4. Implement addCard() method for deck building\n5. Implement drawCard() method that removes and returns top card\n6. Implement shuffle() method using random number generation\n7. Add size(), isEmpty(), and isValid() utility methods\n8. Include proper validation for deck constraints (20 cards, max 2 copies)",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 8
+          },
+          {
+            "id": 2,
+            "title": "Design Hand Class Structure",
+            "description": "Create the Hand class with 4-card limit and card management",
+            "details": "1. Create Hand.h header file with class definition\n2. Implement private member for storing cards (vector of unique_ptr<Card>)\n3. Define MAX_HAND_SIZE constant as 4\n4. Add constructor and destructor\n5. Implement addCard() method with hand size validation\n6. Implement playCard() method that removes and returns card by index\n7. Add size(), isFull(), and getCard() utility methods\n8. Include proper bounds checking and error handling",
+            "status": "done",
+            "dependencies": [
+              1
+            ],
+            "parentTaskId": 8
+          },
+          {
+            "id": 3,
+            "title": "Implement Deck Class Methods",
+            "description": "Implement the Deck class methods in Deck.cpp",
+            "details": "1. Create Deck.cpp implementation file\n2. Implement constructor and destructor\n3. Implement addCard() with validation for deck building rules\n4. Implement drawCard() with proper card removal and return\n5. Implement shuffle() using std::random_shuffle or std::shuffle\n6. Implement size(), isEmpty() utility methods\n7. Implement isValid() method to check 20-card limit and max 2 copies rule\n8. Add proper error handling and edge case management",
+            "status": "done",
+            "dependencies": [
+              1,
+              2
+            ],
+            "parentTaskId": 8
+          },
+          {
+            "id": 4,
+            "title": "Implement Hand Class Methods",
+            "description": "Implement the Hand class methods in Hand.cpp",
+            "details": "1. Create Hand.cpp implementation file\n2. Implement constructor and destructor\n3. Implement addCard() with hand size limit validation\n4. Implement playCard() with bounds checking and card removal\n5. Implement size(), isFull() utility methods\n6. Implement getCard() with const correctness and bounds checking\n7. Add proper error handling for invalid operations\n8. Include logging or debug output for hand operations",
+            "status": "done",
+            "dependencies": [
+              2,
+              3
+            ],
+            "parentTaskId": 8
+          },
+          {
+            "id": 5,
+            "title": "Integrate with GameState",
+            "description": "Integrate Deck and Hand classes with the existing GameState system",
+            "details": "1. Add Deck and Hand includes to GameState.h\n2. Add player deck and hand members to GameState class\n3. Update GameState constructor to initialize decks and hands\n4. Add methods to access player decks and hands\n5. Integrate deck/hand operations with turn management\n6. Update game initialization to create starter decks\n7. Add deck/hand state to game serialization if applicable\n8. Ensure proper cleanup and memory management",
+            "status": "done",
+            "dependencies": [
+              3,
+              4
+            ],
+            "parentTaskId": 8
+          },
+          {
+            "id": 6,
+            "title": "Create Unit Tests",
+            "description": "Create comprehensive unit tests for Deck and Hand classes",
+            "details": "1. Create test_Deck.cpp for Deck class testing\n2. Create test_Hand.cpp for Hand class testing\n3. Test deck creation, shuffling, and drawing\n4. Test hand management with size limits\n5. Test deck validation rules (20 cards, max 2 copies)\n6. Test edge cases like empty decks/hands\n7. Test integration with card system\n8. Add performance tests for large deck operations",
+            "status": "done",
+            "dependencies": [
+              5
+            ],
+            "parentTaskId": 8
+          }
+        ]
+      },
+      {
+        "id": 9,
+        "title": "Implement Card Play Mechanics",
+        "description": "Create the system for playing cards from hand, spending steam resources, and adding new pieces to the board.",
+        "details": "1. Implement card selection and validation\n2. Create steam cost payment system\n3. Implement piece placement from cards\n4. Create valid placement detection\n5. Implement card effect resolution\n\nPseudo-code for card play system:\n```cpp\nclass CardPlaySystem {\npublic:\n    static bool canPlayCard(const GameState& gameState, PlayerSide player, size_t handIndex);\n    static bool playCard(GameState& gameState, PlayerSide player, size_t handIndex, Position targetPos);\n    static std::vector<Position> getValidPlacementPositions(const GameState& gameState, PlayerSide player, const Card* card);\n};\n\nbool CardPlaySystem::playCard(GameState& gameState, PlayerSide player, size_t handIndex, Position targetPos) {\n    if (!canPlayCard(gameState, player, handIndex)) {\n        return false;\n    }\n    \n    const Card* card = gameState.getPlayerHand(player).getCard(handIndex);\n    int steamCost = card->getSteamCost();\n    \n    // Check if player has enough steam\n    if (gameState.getResourceSystem().getSteam(player) < steamCost) {\n        return false;\n    }\n    \n    // Check if target position is valid for this card\n    auto validPositions = getValidPlacementPositions(gameState, player, card);\n    if (std::find(validPositions.begin(), validPositions.end(), targetPos) == validPositions.end()) {\n        return false;\n    }\n    \n    // Spend steam\n    gameState.getResourceSystem().spendSteam(player, steamCost);\n    \n    // Play the card\n    std::unique_ptr<Card> playedCard = gameState.getPlayerHand(player).playCard(handIndex);\n    playedCard->play(gameState, player);\n    \n    // Draw a new card if possible\n    if (!gameState.getPlayerDeck(player).isEmpty()) {\n        gameState.getPlayerHand(player).addCard(gameState.getPlayerDeck(player).drawCard());\n    }\n    \n    return true;\n}\n```",
+        "testStrategy": "1. Unit tests for card play validation\n2. Verify steam cost payment\n3. Test piece placement from cards\n4. Validate card effect resolution\n5. Ensure proper hand/deck updates after card play",
+        "priority": "high",
+        "dependencies": [
+          6,
+          8
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Implement TurnManager Card Play Processing",
+            "description": "Replace the placeholder processPlayCardAction method in TurnManager with actual card play logic using the existing CardPlayValidator",
+            "details": "1. Update TurnManager::processPlayCardAction() to use CardPlayValidator::executeCardPlay()\n2. Add proper error handling and result conversion\n3. Integrate with turn switching logic\n4. Add validation for player turn and game state",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 9
+          },
+          {
+            "id": 2,
+            "title": "Add Card UI Rendering",
+            "description": "Implement hand display in the main game loop showing the local player's cards with names, steam costs, and visual feedback",
+            "details": "1. Add card rendering function to main.cpp\n2. Display cards horizontally below the game board\n3. Show card name, steam cost, and type\n4. Add visual feedback for playable/unplayable cards based on steam\n5. Position cards appropriately using GraphicsManager scaling",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 9
+          },
+          {
+            "id": 3,
+            "title": "Extend InputManager for Card Interaction",
+            "description": "Add card click detection and card play interaction to InputManager, implementing the click-card-then-click-target workflow",
+            "details": "1. Add card area click detection to InputManager\n2. Implement card selection state management\n3. Add target selection for card play\n4. Integrate with existing mouse handling system\n5. Add visual feedback for selected cards and valid targets",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 9
+          },
+          {
+            "id": 4,
+            "title": "Add Network Protocol for Card Play",
+            "description": "Extend the network protocol to support card play messages for multiplayer synchronization",
+            "details": "1. Add CardPlayToServer message type to NetworkProtocol.h\n2. Implement sf::Packet operators for card play data\n3. Add server-side card play message handling\n4. Add client-side card play result handling\n5. Ensure proper game state synchronization",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 9
+          }
+        ]
+      },
+      {
+        "id": 10,
+        "title": "Implement Game State Management and Turn System",
+        "description": "Create the system for managing game state, turn progression, and win conditions.",
+        "details": "1. Implement game state class with all game components\n2. Create turn system with phases (draw, play, move)\n3. Implement win condition detection (king death)\n4. Create game initialization and reset\n5. Implement game state serialization for save/load\n\nPseudo-code for game state management:\n```cpp\nclass GameState {\nprivate:\n    GameBoard board;\n    ResourceSystem resourceSystem;\n    std::array<Hand, 2> playerHands;\n    std::array<Deck, 2> playerDecks;\n    PlayerSide currentPlayer;\n    GamePhase currentPhase;\n    bool gameOver;\n    PlayerSide winner;\n    \npublic:\n    GameState();\n    \n    void initializeGame();\n    void startTurn();\n    void endTurn();\n    void nextPhase();\n    \n    bool isGameOver() const;\n    PlayerSide getWinner() const;\n    void checkWinConditions();\n    \n    GameBoard& getBoard();\n    ResourceSystem& getResourceSystem();\n    Hand& getPlayerHand(PlayerSide player);\n    Deck& getPlayerDeck(PlayerSide player);\n    PlayerSide getCurrentPlayer() const;\n    GamePhase getCurrentPhase() const;\n};\n\nvoid GameState::checkWinConditions() {\n    bool player1KingAlive = false;\n    bool player2KingAlive = false;\n    \n    // Check if kings are alive\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            if (!square.isEmpty()) {\n                Piece* piece = square.getPiece();\n                if (dynamic_cast<King*>(piece)) {\n                    if (piece->getOwner() == PlayerSide::PLAYER_1) {\n                        player1KingAlive = true;\n                    } else {\n                        player2KingAlive = true;\n                    }\n                }\n            }\n        }\n    }\n    \n    if (!player1KingAlive) {\n        gameOver = true;\n        winner = PlayerSide::PLAYER_2;\n    } else if (!player2KingAlive) {\n        gameOver = true;\n        winner = PlayerSide::PLAYER_1;\n    }\n}\n```",
+        "testStrategy": "1. Unit tests for turn progression\n2. Verify win condition detection\n3. Test game initialization\n4. Validate phase transitions\n5. Ensure proper game state serialization",
+        "priority": "high",
+        "dependencies": [
+          4,
+          6,
+          9
+        ],
+        "status": "done",
+        "subtasks": [
+          {
+            "id": 1,
+            "title": "Verify Game State Integration",
+            "description": "Test and verify that all game state components work together correctly",
+            "details": "1. Test GameState initialization and reset functionality\\n2. Verify turn progression and player switching\\n3. Test steam generation and resource management\\n4. Verify card system integration\\n5. Test win condition detection\\n6. Ensure proper game state serialization",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 10
+          },
+          {
+            "id": 2,
+            "title": "Implement Game Phase System",
+            "description": "Add proper game phase transitions (draw, play, move phases) to the turn system",
+            "details": "1. Define GamePhase enum with DRAW, PLAY, MOVE phases\\n2. Update TurnManager to handle phase transitions\\n3. Implement phase-specific action validation\\n4. Add phase progression logic within turns\\n5. Update UI to display current phase\\n6. Test phase transitions and restrictions",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 10
+          },
+          {
+            "id": 3,
+            "title": "Enhance Win Condition System",
+            "description": "Improve and test the win condition detection system",
+            "details": "1. Test king death detection in GameRules\\n2. Verify proper game result setting\\n3. Add additional win conditions if needed\\n4. Test game over state transitions\\n5. Ensure proper cleanup when game ends\\n6. Add win condition notifications",
+            "status": "done",
+            "dependencies": [],
+            "parentTaskId": 10
+          }
+        ]
+      },
+      {
+        "id": 11,
+        "title": "Implement Game Board Visualization with SFML",
+        "description": "Create the visual representation of the game board, pieces, and control indicators using SFML.",
+        "details": "1. Create board grid visualization\n2. Implement piece sprites and rendering\n3. Create visual indicators for square control\n4. Implement highlighting for valid moves\n5. Create animations for piece movement and combat\n\nPseudo-code for board visualization:\n```cpp\nclass BoardView {\nprivate:\n    sf::RenderWindow& window;\n    sf::Texture boardTexture;\n    sf::Sprite boardSprite;\n    std::map<PieceType, sf::Texture> pieceTextures;\n    std::vector<sf::Sprite> pieceSprites;\n    \n    float squareSize;\n    sf::Vector2f boardPosition;\n    \npublic:\n    BoardView(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateView(const GameBoard& board);\n    void drawBoard();\n    void drawPieces(const GameBoard& board);\n    void drawControlIndicators(const GameBoard& board);\n    void drawValidMoves(const std::vector<Position>& validMoves);\n    \n    Position screenToBoard(sf::Vector2f screenPos) const;\n    sf::Vector2f boardToScreen(Position boardPos) const;\n};\n\nvoid BoardView::drawControlIndicators(const GameBoard& board) {\n    for (int y = 0; y < 8; y++) {\n        for (int x = 0; x < 8; x++) {\n            const Square& square = board.getSquare(x, y);\n            PlayerSide controller = InfluenceSystem::getControllingPlayer(square);\n            \n            if (controller != PlayerSide::NONE) {\n                sf::RectangleShape indicator(sf::Vector2f(squareSize, squareSize));\n                indicator.setPosition(boardToScreen(Position{x, y}));\n                \n                if (controller == PlayerSide::PLAYER_1) {\n                    indicator.setFillColor(sf::Color(0, 0, 255, 64)); // Blue with transparency\n                } else {\n                    indicator.setFillColor(sf::Color(255, 0, 0, 64)); // Red with transparency\n                }\n                \n                window.draw(indicator);\n            }\n        }\n    }\n}\n```",
+        "testStrategy": "1. Visual verification of board rendering\n2. Test piece sprite rendering\n3. Verify control indicators\n4. Test move highlighting\n5. Validate animations and transitions",
+        "priority": "medium",
+        "dependencies": [
+          1,
+          2,
+          5
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 12,
+        "title": "Implement User Interface for Game State and Resources",
+        "description": "Create the UI elements for displaying game state, player resources, and turn information.",
+        "details": "1. Implement steam resource display\n2. Create turn and phase indicators\n3. Implement player information display\n4. Create game state notifications\n5. Implement UI layout and styling\n\nPseudo-code for UI implementation:\n```cpp\nclass GameUI {\nprivate:\n    sf::RenderWindow& window;\n    sf::Font font;\n    \n    sf::Text player1Info;\n    sf::Text player2Info;\n    sf::Text phaseInfo;\n    sf::Text steamInfo;\n    sf::Text notificationText;\n    \npublic:\n    GameUI(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateUI(const GameState& gameState);\n    void drawUI();\n    \n    void showNotification(const std::string& message, float duration = 3.0f);\n};\n\nvoid GameUI::updateUI(const GameState& gameState) {\n    // Update player info\n    player1Info.setString(\"Player 1\");\n    player2Info.setString(\"Player 2\");\n    \n    // Update phase info\n    std::string phaseStr;\n    switch (gameState.getCurrentPhase()) {\n        case GamePhase::DRAW: phaseStr = \"Draw Phase\"; break;\n        case GamePhase::PLAY: phaseStr = \"Play Phase\"; break;\n        case GamePhase::MOVE: phaseStr = \"Move Phase\"; break;\n    }\n    phaseInfo.setString(phaseStr);\n    \n    // Update steam info\n    int player1Steam = gameState.getResourceSystem().getSteam(PlayerSide::PLAYER_1);\n    int player2Steam = gameState.getResourceSystem().getSteam(PlayerSide::PLAYER_2);\n    steamInfo.setString(\"Steam - P1: \" + std::to_string(player1Steam) + \n                        \" | P2: \" + std::to_string(player2Steam));\n    \n    // Highlight current player\n    if (gameState.getCurrentPlayer() == PlayerSide::PLAYER_1) {\n        player1Info.setFillColor(sf::Color::Yellow);\n        player2Info.setFillColor(sf::Color::White);\n    } else {\n        player1Info.setFillColor(sf::Color::White);\n        player2Info.setFillColor(sf::Color::Yellow);\n    }\n}\n```",
+        "testStrategy": "1. Visual verification of UI elements\n2. Test resource display accuracy\n3. Verify turn and phase indicators\n4. Test notification system\n5. Validate UI updates on game state changes",
+        "priority": "medium",
+        "dependencies": [
+          6,
+          10,
+          11
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 13,
+        "title": "Implement Hand and Card Visualization",
+        "description": "Create the visual representation of player hands and cards with interactive elements.",
+        "details": "1. Implement card visual design\n2. Create hand layout and positioning\n3. Implement card selection and highlighting\n4. Create card detail view\n5. Implement drag-and-drop for card play\n\nPseudo-code for hand visualization:\n```cpp\nclass HandView {\nprivate:\n    sf::RenderWindow& window;\n    sf::Font font;\n    std::vector<sf::RectangleShape> cardShapes;\n    std::vector<sf::Text> cardTexts;\n    \n    sf::Vector2f handPosition;\n    float cardWidth;\n    float cardHeight;\n    float cardSpacing;\n    \n    size_t selectedCardIndex;\n    bool isDragging;\n    sf::Vector2f dragOffset;\n    \npublic:\n    HandView(sf::RenderWindow& window);\n    \n    void loadAssets();\n    void updateView(const Hand& hand);\n    void drawHand();\n    \n    size_t getCardIndexAtPosition(sf::Vector2f position) const;\n    bool handleMouseDown(sf::Vector2f position);\n    bool handleMouseMove(sf::Vector2f position);\n    bool handleMouseUp(sf::Vector2f position, GameState& gameState);\n};\n\nvoid HandView::updateView(const Hand& hand) {\n    cardShapes.clear();\n    cardTexts.clear();\n    \n    for (size_t i = 0; i < hand.size(); i++) {\n        const Card* card = hand.getCard(i);\n        \n        sf::RectangleShape cardShape(sf::Vector2f(cardWidth, cardHeight));\n        cardShape.setPosition(handPosition.x + i * (cardWidth + cardSpacing), handPosition.y);\n        cardShape.setFillColor(sf::Color::White);\n        cardShape.setOutlineThickness(2.0f);\n        cardShape.setOutlineColor(i == selectedCardIndex ? sf::Color::Yellow : sf::Color::Black);\n        \n        sf::Text nameText(card->getName(), font, 12);\n        nameText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 5));\n        \n        sf::Text costText(\"Cost: \" + std::to_string(card->getSteamCost()), font, 10);\n        costText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 25));\n        \n        sf::Text descText(card->getDescription(), font, 8);\n        descText.setPosition(cardShape.getPosition() + sf::Vector2f(5, 45));\n        \n        cardShapes.push_back(cardShape);\n        cardTexts.push_back(nameText);\n        cardTexts.push_back(costText);\n        cardTexts.push_back(descText);\n    }\n}\n```",
+        "testStrategy": "1. Visual verification of card rendering\n2. Test card selection and highlighting\n3. Verify drag-and-drop functionality\n4. Test card detail view\n5. Validate hand updates when cards are played or drawn",
+        "priority": "medium",
+        "dependencies": [
+          8,
+          11
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 14,
+        "title": "Implement Input Handling and Game Controls",
+        "description": "Create the input handling system for player interactions with the game board, pieces, and cards.",
+        "details": "1. Implement mouse input handling\n2. Create piece selection and movement\n3. Implement card selection and play\n4. Create turn and phase control buttons\n5. Implement keyboard shortcuts\n\nPseudo-code for input handling:\n```cpp\nclass InputHandler {\nprivate:\n    sf::RenderWindow& window;\n    GameState& gameState;\n    BoardView& boardView;\n    HandView& handView;\n    \n    bool pieceSelected;\n    Position selectedPiecePos;\n    std::vector<Position> validMoves;\n    \npublic:\n    InputHandler(sf::RenderWindow& window, GameState& gameState, BoardView& boardView, HandView& handView);\n    \n    void handleEvents();\n    void handleMouseClick(sf::Vector2f mousePos);\n    void handlePieceSelection(Position boardPos);\n    void handlePieceMovement(Position boardPos);\n    void handleCardPlay(size_t cardIndex, Position boardPos);\n    void handleEndTurnButton();\n};\n\nvoid InputHandler::handleMouseClick(sf::Vector2f mousePos) {\n    // Check if clicked on the board\n    Position boardPos = boardView.screenToBoard(mousePos);\n    if (boardPos.x >= 0 && boardPos.x < 8 && boardPos.y >= 0 && boardPos.y < 8) {\n        if (pieceSelected) {\n            handlePieceMovement(boardPos);\n        } else {\n            handlePieceSelection(boardPos);\n        }\n        return;\n    }\n    \n    // Check if clicked on a card in hand\n    size_t cardIndex = handView.getCardIndexAtPosition(mousePos);\n    if (cardIndex < gameState.getPlayerHand(gameState.getCurrentPlayer()).size()) {\n        // Start card drag operation\n        handView.handleMouseDown(mousePos);\n        return;\n    }\n    \n    // Check if clicked on end turn button\n    // ...\n}\n```",
+        "testStrategy": "1. Test mouse input handling\n2. Verify piece selection and movement\n3. Test card selection and play\n4. Validate turn and phase controls\n5. Ensure proper input validation and error handling",
+        "priority": "high",
+        "dependencies": [
+          11,
+          12,
+          13
+        ],
+        "status": "pending",
+        "subtasks": []
+      },
+      {
+        "id": 15,
+        "title": "Implement Simple AI Opponent",
+        "description": "Create a basic AI opponent for single-player testing with decision-making for piece movement and card play.",
+        "details": "1. Implement AI decision-making framework\n2. Create simple evaluation function for board state\n3. Implement basic move selection algorithm\n4. Create card play decision logic\n5. Implement difficulty levels\n\nPseudo-code for AI implementation:\n```cpp\nclass AIPlayer {\nprivate:\n    GameState& gameState;\n    PlayerSide side;\n    int difficultyLevel;\n    \n    struct Move {\n        Position from;\n        Position to;\n        float score;\n    };\n    \n    struct CardPlay {\n        size_t cardIndex;\n        Position targetPos;\n        float score;\n    };\n    \npublic:\n    AIPlayer(GameState& gameState, PlayerSide side, int difficultyLevel = 1);\n    \n    void takeTurn();\n    \nprivate:\n    float evaluateBoard();\n    std::vector<Move> generatePossibleMoves();\n    std::vector<CardPlay> generatePossibleCardPlays();\n    Move selectBestMove();\n    CardPlay selectBestCardPlay();\n};\n\nvoid AIPlayer::takeTurn() {\n    // Draw phase happens automatically\n    \n    // Play phase - try to play a card if possible\n    CardPlay bestCardPlay = selectBestCardPlay();\n    if (bestCardPlay.score > 0) {\n        const Card* card = gameState.getPlayerHand(side).getCard(bestCardPlay.cardIndex);\n        if (gameState.getResourceSystem().getSteam(side) >= card->getSteamCost()) {\n            CardPlaySystem::playCard(gameState, side, bestCardPlay.cardIndex, bestCardPlay.targetPos);\n        }\n    }\n    \n    // Move phase - move a piece\n    Move bestMove = selectBestMove();\n    if (bestMove.score > 0) {\n        Piece* piece = gameState.getBoard().getSquare(bestMove.from.x, bestMove.from.y).getPiece();\n        piece->executeMove(gameState.getBoard(), bestMove.from, bestMove.to);\n    }\n    \n    // End turn\n    gameState.endTurn();\n}\n```",
+        "testStrategy": "1. Test AI decision-making\n2. Verify move selection logic\n3. Test card play decisions\n4. Validate different difficulty levels\n5. Benchmark AI performance and response time",
+        "priority": "low",
+        "dependencies": [
+          10
+        ],
+        "status": "pending",
+        "subtasks": []
+      }
+    ],
+    "metadata": {
+      "created": "2025-07-06T23:30:43.445Z",
+      "updated": "2025-07-06T23:30:43.446Z",
+      "description": "Tasks for master context"
     }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- rework server_main to handle many concurrent games
- introduce `GameSession` struct and assign players to sessions
- broadcast state only to players in a session
- remove two-player connection limit and default new connections to neutral side

## Testing
- `cmake ..` *(fails: Missing X11 libs)*

------
https://chatgpt.com/codex/tasks/task_e_686acb6b42948322bf4392a188f1622a