### PR TITLE
Refactor main menu and hand rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,8 @@ set(CLIENT_SOURCES
     src/main.cpp
     src/InputManager.cpp
     src/GraphicsManager.cpp
+    src/HandRenderer.cpp
+    src/Menu.cpp
 )
 set(SERVER_SOURCES src/server_main.cpp)
 

--- a/include/HandRenderer.h
+++ b/include/HandRenderer.h
@@ -1,0 +1,20 @@
+#ifndef BAYOU_BONANZA_HAND_RENDERER_H
+#define BAYOU_BONANZA_HAND_RENDERER_H
+
+#include <SFML/Graphics.hpp>
+#include "GameState.h"
+#include "PlayerSide.h"
+#include "GraphicsManager.h"
+
+namespace BayouBonanza {
+
+void renderPlayerHand(sf::RenderWindow& window,
+                      const GameState& gameState,
+                      PlayerSide player,
+                      const GraphicsManager& graphicsManager,
+                      const sf::Font& font,
+                      int selectedCardIndex = -1);
+
+} // namespace BayouBonanza
+
+#endif // BAYOU_BONANZA_HAND_RENDERER_H

--- a/include/Menu.h
+++ b/include/Menu.h
@@ -1,0 +1,43 @@
+#ifndef BAYOU_BONANZA_MENU_H
+#define BAYOU_BONANZA_MENU_H
+
+#include <SFML/Graphics.hpp>
+#include <SFML/Network.hpp>
+#include <string>
+#include "GraphicsManager.h"
+#include "CardCollection.h"
+#include "PlayerSide.h"
+
+namespace BayouBonanza {
+
+enum class MainMenuOption {
+    DECK_EDITOR,
+    PLAY_HUMAN,
+    PLAY_AI,
+    NONE
+};
+
+std::string runLoginScreen(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           const sf::Font& font);
+
+void showPlaceholderScreen(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           const std::string& message,
+                           const sf::Font& font);
+
+MainMenuOption runMainMenu(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           sf::TcpSocket& socket,
+                           CardCollection& collection,
+                           Deck& deck,
+                           PlayerSide& playerSide,
+                           std::string& username,
+                           int& currentRating,
+                           sf::Packet& gameStartPacketData,
+                           bool& gameStartReceived,
+                           const sf::Font& font);
+
+} // namespace BayouBonanza
+
+#endif // BAYOU_BONANZA_MENU_H

--- a/src/HandRenderer.cpp
+++ b/src/HandRenderer.cpp
@@ -1,0 +1,88 @@
+#include "HandRenderer.h"
+#include "Card.h"
+
+namespace BayouBonanza {
+
+void renderPlayerHand(sf::RenderWindow& window,
+                      const GameState& gameState,
+                      PlayerSide player,
+                      const GraphicsManager& graphicsManager,
+                      const sf::Font& font,
+                      int selectedCardIndex) {
+    const Hand& hand = gameState.getHand(player);
+    if (hand.size() == 0) {
+        return;
+    }
+
+    auto boardParams = graphicsManager.getBoardRenderParams();
+    int playerSteam = gameState.getSteam(player);
+
+    float cardWidth = 120.0f;
+    float cardHeight = 120.0f;
+    float cardSpacing = 10.0f;
+    float totalHandWidth = hand.size() * cardWidth + (hand.size() - 1) * cardSpacing;
+
+    float handStartX = (GraphicsManager::BASE_WIDTH - totalHandWidth) / 2.0f;
+    float handY = boardParams.boardStartY + boardParams.boardSize + 10.0f;
+
+    for (size_t i = 0; i < hand.size(); ++i) {
+        const Card* card = hand.getCard(i);
+        if (!card) {
+            continue;
+        }
+
+        float cardX = handStartX + i * (cardWidth + cardSpacing);
+
+        sf::RectangleShape cardRect(sf::Vector2f(cardWidth, cardHeight));
+        cardRect.setPosition(cardX, handY);
+
+        bool canAfford = playerSteam >= card->getSteamCost();
+        bool isSelected = static_cast<int>(i) == selectedCardIndex;
+
+        if (isSelected) {
+            cardRect.setFillColor(sf::Color(100, 150, 255, 200));
+            cardRect.setOutlineColor(sf::Color::Yellow);
+            cardRect.setOutlineThickness(3.0f);
+        } else if (canAfford) {
+            cardRect.setFillColor(sf::Color(60, 80, 60, 180));
+            cardRect.setOutlineColor(sf::Color::White);
+            cardRect.setOutlineThickness(1.0f);
+        } else {
+            cardRect.setFillColor(sf::Color(80, 60, 60, 180));
+            cardRect.setOutlineColor(sf::Color(128, 128, 128));
+            cardRect.setOutlineThickness(1.0f);
+        }
+
+        window.draw(cardRect);
+
+        sf::Text nameText;
+        nameText.setFont(font);
+        nameText.setCharacterSize(14);
+        nameText.setFillColor(sf::Color::White);
+        nameText.setString(card->getName());
+        sf::FloatRect nameBounds = nameText.getLocalBounds();
+        nameText.setPosition(cardX + (cardWidth - nameBounds.width) / 2.0f, handY + 10.0f);
+        window.draw(nameText);
+
+        sf::Text costText;
+        costText.setFont(font);
+        costText.setCharacterSize(16);
+        costText.setFillColor(canAfford ? sf::Color::Cyan : sf::Color::Red);
+        costText.setString("Steam: " + std::to_string(card->getSteamCost()));
+        sf::FloatRect costBounds = costText.getLocalBounds();
+        costText.setPosition(cardX + (cardWidth - costBounds.width) / 2.0f, handY + cardHeight - 25.0f);
+        window.draw(costText);
+
+        sf::Text typeText;
+        typeText.setFont(font);
+        typeText.setCharacterSize(12);
+        typeText.setFillColor(sf::Color::Yellow);
+        std::string typeStr = (card->getCardType() == CardType::PIECE_CARD) ? "Piece" : "Effect";
+        typeText.setString(typeStr);
+        sf::FloatRect typeBounds = typeText.getLocalBounds();
+        typeText.setPosition(cardX + (cardWidth - typeBounds.width) / 2.0f, handY + 35.0f);
+        window.draw(typeText);
+    }
+}
+
+} // namespace BayouBonanza

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1,0 +1,260 @@
+#include "Menu.h"
+#include "NetworkProtocol.h"
+#include "GameState.h"
+#include <iostream>
+
+namespace BayouBonanza {
+
+std::string runLoginScreen(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           const sf::Font& font) {
+    std::string username;
+
+    sf::Text promptText;
+    promptText.setFont(font);
+    promptText.setCharacterSize(32);
+    promptText.setFillColor(sf::Color::White);
+    promptText.setString("Enter Username");
+
+    sf::Text inputText;
+    inputText.setFont(font);
+    inputText.setCharacterSize(28);
+    inputText.setFillColor(sf::Color::Cyan);
+
+    sf::RectangleShape inputBox(sf::Vector2f(400.f, 50.f));
+    inputBox.setFillColor(sf::Color(30, 30, 30));
+    inputBox.setOutlineColor(sf::Color::White);
+    inputBox.setOutlineThickness(2.f);
+
+    bool done = false;
+    while (window.isOpen() && !done) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                window.close();
+                return "";
+            } else if (event.type == sf::Event::Resized) {
+                graphicsManager.updateView();
+            } else if (event.type == sf::Event::TextEntered) {
+                if (event.text.unicode == 8) {
+                    if (!username.empty()) username.pop_back();
+                } else if (event.text.unicode == 13 || event.text.unicode == 10) {
+                    if (!username.empty()) done = true;
+                } else if (event.text.unicode < 128 && std::isprint(event.text.unicode)) {
+                    username += static_cast<char>(event.text.unicode);
+                }
+            }
+        }
+
+        graphicsManager.applyView();
+        window.clear(sf::Color(10, 50, 20));
+
+        float centerX = GraphicsManager::BASE_WIDTH / 2.f;
+        float centerY = GraphicsManager::BASE_HEIGHT / 2.f;
+
+        sf::FloatRect promptBounds = promptText.getLocalBounds();
+        promptText.setPosition(centerX - promptBounds.width / 2.f, centerY - 80.f);
+
+        inputBox.setPosition(centerX - inputBox.getSize().x / 2.f, centerY - inputBox.getSize().y / 2.f);
+
+        inputText.setString(username);
+        inputText.setPosition(inputBox.getPosition().x + 10.f, inputBox.getPosition().y + 10.f);
+
+        window.draw(promptText);
+        window.draw(inputBox);
+        window.draw(inputText);
+        window.display();
+    }
+
+    return username;
+}
+
+void showPlaceholderScreen(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           const std::string& message,
+                           const sf::Font& font) {
+    while (window.isOpen()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                window.close();
+                return;
+            } else if (event.type == sf::Event::KeyPressed || event.type == sf::Event::MouseButtonPressed) {
+                return;
+            } else if (event.type == sf::Event::Resized) {
+                graphicsManager.updateView();
+            }
+        }
+
+        graphicsManager.applyView();
+        window.clear(sf::Color(10, 50, 20));
+
+        sf::Text text;
+        text.setFont(font);
+        text.setString(message + "\n(Press any key)");
+        text.setCharacterSize(32);
+        text.setFillColor(sf::Color::White);
+
+        sf::FloatRect bounds = text.getLocalBounds();
+        text.setOrigin(bounds.left + bounds.width / 2.f, bounds.top + bounds.height / 2.f);
+        text.setPosition(GraphicsManager::BASE_WIDTH / 2.f, GraphicsManager::BASE_HEIGHT / 2.f);
+
+        window.draw(text);
+        window.display();
+    }
+}
+
+MainMenuOption runMainMenu(sf::RenderWindow& window,
+                           GraphicsManager& graphicsManager,
+                           sf::TcpSocket& socket,
+                           CardCollection& collection,
+                           Deck& deck,
+                           PlayerSide& playerSide,
+                           std::string& username,
+                           int& currentRating,
+                           sf::Packet& gameStartPacketData,
+                           bool& gameStartReceived,
+                           const sf::Font& font) {
+    int selected = 0;
+    const char* optionTexts[] = {"Deck Editor", "Play Against Human", "Play Against AI"};
+    const int optionCount = 3;
+
+    while (window.isOpen()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
+                window.close();
+                return MainMenuOption::NONE;
+            } else if (event.type == sf::Event::KeyPressed) {
+                if (event.key.code == sf::Keyboard::Up) {
+                    selected = (selected + optionCount - 1) % optionCount;
+                } else if (event.key.code == sf::Keyboard::Down) {
+                    selected = (selected + 1) % optionCount;
+                } else if (event.key.code == sf::Keyboard::Enter || event.key.code == sf::Keyboard::Return) {
+                    switch (selected) {
+                        case 0: return MainMenuOption::DECK_EDITOR;
+                        case 1: {
+                            sf::Packet matchmakingPacket;
+                            matchmakingPacket << MessageType::RequestMatchmaking;
+                            if (socket.send(matchmakingPacket) == sf::Socket::Done) {
+                                std::cout << "Matchmaking request sent to server" << std::endl;
+                            } else {
+                                std::cerr << "Failed to send matchmaking request" << std::endl;
+                            }
+                            break;
+                        }
+                        case 2:
+                            return MainMenuOption::PLAY_AI;
+                    }
+                }
+            } else if (event.type == sf::Event::Resized) {
+                graphicsManager.updateView();
+            }
+        }
+
+        sf::Packet receivedPacket;
+        sf::Socket::Status status = socket.receive(receivedPacket);
+        if (status == sf::Socket::Done) {
+            MessageType messageType;
+            if (receivedPacket >> messageType) {
+                switch (messageType) {
+                    case MessageType::PlayerAssignment: {
+                        uint8_t side_uint8;
+                        if (receivedPacket >> side_uint8) {
+                            playerSide = static_cast<PlayerSide>(side_uint8);
+                            std::cout << "Assigned player side: Player "
+                                      << (playerSide == PlayerSide::PLAYER_ONE ? "One" : "Two")
+                                      << std::endl;
+                        }
+                        break;
+                    }
+                    case MessageType::CardCollectionData: {
+                        std::string data;
+                        if (receivedPacket >> data) {
+                            collection.deserialize(data);
+                            std::cout << "Collection received with " << collection.size() << " cards" << std::endl;
+                        }
+                        break;
+                    }
+                    case MessageType::DeckData: {
+                        std::string data;
+                        if (receivedPacket >> data) {
+                            deck.deserialize(data);
+                            std::cout << "Deck received with " << deck.size() << " cards" << std::endl;
+                        }
+                        break;
+                    }
+                    case MessageType::WaitingForOpponent:
+                        std::cout << "Waiting for opponent..." << std::endl;
+                        break;
+                    case MessageType::GameStart: {
+                        std::cout << "Game start received in main menu - storing packet data and transitioning to game!" << std::endl;
+                        gameStartPacketData.clear();
+                        gameStartPacketData << MessageType::GameStart;
+                        std::string p1_username, p2_username;
+                        int p1_rating, p2_rating;
+                        GameState tempGameState;
+                        if (receivedPacket >> p1_username >> p1_rating >> p2_username >> p2_rating >> tempGameState) {
+                            gameStartPacketData << p1_username << p1_rating << p2_username << p2_rating << tempGameState;
+                            gameStartReceived = true;
+                            return MainMenuOption::PLAY_HUMAN;
+                        } else {
+                            std::cerr << "Error: Failed to deserialize GameStart data in main menu" << std::endl;
+                        }
+                        break;
+                    }
+                    default:
+                        std::cout << "Received unhandled message type in main menu: "
+                                  << static_cast<int>(messageType) << std::endl;
+                        break;
+                }
+            }
+        }
+
+        graphicsManager.applyView();
+        window.clear(sf::Color(10, 50, 20));
+
+        sf::Text title;
+        title.setFont(font);
+        title.setString("Main Menu");
+        title.setCharacterSize(40);
+        title.setFillColor(sf::Color::White);
+        sf::FloatRect titleBounds = title.getLocalBounds();
+        title.setOrigin(titleBounds.left + titleBounds.width / 2.f,
+                         titleBounds.top + titleBounds.height / 2.f);
+        title.setPosition(GraphicsManager::BASE_WIDTH / 2.f,
+                           GraphicsManager::BASE_HEIGHT / 2.f - 120.f);
+        window.draw(title);
+
+        sf::Text playerInfo;
+        playerInfo.setFont(font);
+        playerInfo.setString("Player: " + username + " | Rating: " + std::to_string(currentRating));
+        playerInfo.setCharacterSize(20);
+        playerInfo.setFillColor(sf::Color::Cyan);
+        sf::FloatRect playerBounds = playerInfo.getLocalBounds();
+        playerInfo.setOrigin(playerBounds.left + playerBounds.width / 2.f,
+                             playerBounds.top + playerBounds.height / 2.f);
+        playerInfo.setPosition(GraphicsManager::BASE_WIDTH / 2.f,
+                                GraphicsManager::BASE_HEIGHT / 2.f - 80.f);
+        window.draw(playerInfo);
+
+        for (int i = 0; i < optionCount; ++i) {
+            sf::Text option;
+            option.setFont(font);
+            option.setString(optionTexts[i]);
+            option.setCharacterSize(28);
+            option.setFillColor(i == selected ? sf::Color::Yellow : sf::Color::White);
+            sf::FloatRect b = option.getLocalBounds();
+            option.setOrigin(b.left + b.width / 2.f, b.top + b.height / 2.f);
+            option.setPosition(GraphicsManager::BASE_WIDTH / 2.f,
+                                GraphicsManager::BASE_HEIGHT / 2.f - 20.f + i * 50.f);
+            window.draw(option);
+        }
+
+        window.display();
+    }
+
+    return MainMenuOption::NONE;
+}
+
+} // namespace BayouBonanza


### PR DESCRIPTION
## Summary
- modularize menu flows into a dedicated `Menu` module with login, placeholder, and main menu handlers
- extract card hand rendering into new `HandRenderer` utility
- update client build configuration and main loop to use the new helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build --target BayouBonanzaClient`
- `cmake --build build --target GameplayTest TestInitialization`
- `./build/GameplayTest`
- `./build/TestInitialization`


------
https://chatgpt.com/codex/tasks/task_e_6892e16624d88322989013a0a7bc2c5f